### PR TITLE
Prevent a buildings construction image from jittering.

### DIFF
--- a/go.graphics/src/go/graphics/GlCachingDrawer.java
+++ b/go.graphics/src/go/graphics/GlCachingDrawer.java
@@ -40,7 +40,7 @@ public abstract class GlCachingDrawer implements GLDrawContext {
 
 		private int currentTriangles = 0;
 
-		protected void addTirangles(float[] triangles) {
+		protected void addTriangles(float[] triangles) {
 			for (int i = 0; i < triangles.length; i += 5 * 3) {
 				addTexturedTriangle(triangles, i);
 			}
@@ -151,7 +151,7 @@ public abstract class GlCachingDrawer implements GLDrawContext {
 	@Override
 	public void drawTrianglesWithTexture(int textureid, float[] geometry) {
 		GLBuffer buffer = getBuffer(textureid);
-		buffer.addTirangles(geometry);
+		buffer.addTriangles(geometry);
 	}
 
 	@Override

--- a/jsettlers.graphics/src/jsettlers/graphics/image/SingleImage.java
+++ b/jsettlers.graphics/src/jsettlers/graphics/image/SingleImage.java
@@ -329,9 +329,35 @@ public class SingleImage extends Image implements ImageDataPrivider {
 		float left = getOffsetX() + viewX;
 		float top = -getOffsetY() + viewY;
 
-		buffer2.addTirangle(left + u1 * width, top - v1 * height, left + u2
-				* width, top - v2 * height, left + u3 * width, top - v3
-				* height, convertU(u1), convertV(v1), convertU(u2),
-				convertV(v2), convertU(u3), convertV(v3), activeColor);
+		buffer2.addTriangle(
+			alignCoord( left + u1 * width ),
+			alignCoord( top - v1 * height ),
+			alignCoord( left + u2 * width ),
+			alignCoord( top - v2 * height ),
+			alignCoord( left + u3 * width ),
+			alignCoord( top - v3 * height ),
+			convertU(u1),
+			convertV(v1),
+			convertU(u2),
+			convertV(v2),
+			convertU(u3),
+			convertV(v3),
+			activeColor
+		);
+	}
+
+	/**
+	 * In the draw process sub-integer coordinates can be rounded in unexpected ways that is particularly noticeable when redrawing the
+	 * growing image of a building in the construction phase. By aligning to the nearest integer images can be placed in a more
+	 * predictable and controlled manner.
+	 * @param value the coordinate to be aligned.
+	 * @return an aligned coordinate value.
+	 */
+	private float alignCoord( float value )
+	{
+		//At larger scales the issue is still present to some degree which zoomFactor helps to minimize.
+		//TODO need to find the factor based on the zoom level.
+		float zoomFactor = 1.06f;
+		return (float)((Math.floor( value * zoomFactor )) / zoomFactor);
 	}
 }

--- a/jsettlers.graphics/src/jsettlers/graphics/map/draw/DrawBuffer.java
+++ b/jsettlers.graphics/src/jsettlers/graphics/map/draw/DrawBuffer.java
@@ -64,8 +64,8 @@ public class DrawBuffer {
 			currentTriangles += 2;
 		}
 
-		public void addTirangle(float x1, float y1, float x2, float y2, float x3, float y3, float u1, float v1, float u2, float v2, float u3,
-				float v3, int activeColor) {
+		public void addTriangle(float x1, float y1, float x2, float y2, float x3, float y3,
+									float u1, float v1, float u2, float v2, float u3, float v3, int activeColor) {
 			if (currentTriangles >= BUFFER_TRIANGLES - 1) {
 				draw();
 			}

--- a/jsettlers.logic/src/jsettlers/logic/buildings/Building.java
+++ b/jsettlers.logic/src/jsettlers/logic/buildings/Building.java
@@ -206,6 +206,10 @@ public abstract class Building extends AbstractHexMapObject implements IConstruc
 		return couldBePlaced;
 	}
 
+	/**
+	 * Used to set or clear the small red flag atop a building to indicate it is occupied.
+	 * @param place specifies whether the flag should appear or not.
+	 */
 	protected void placeFlag(boolean place) {
 		ShortPoint2D flagPosition = type.getFlag().calculatePoint(pos);
 


### PR DESCRIPTION
For the default zoom level the image shown while a building is
in the construction phase was prone to moving about when redrawn.
This fix corrects this by flooring the coordinates for the
image to the nearest integer.