### PR TITLE
Worker drop animation correction.

### DIFF
--- a/jsettlers.logic/src/jsettlers/logic/movable/strategies/BuildingWorkerStrategy.java
+++ b/jsettlers.logic/src/jsettlers/logic/movable/strategies/BuildingWorkerStrategy.java
@@ -319,6 +319,7 @@ public final class BuildingWorkerStrategy extends MovableStrategy implements IMa
 			}
 		} else {
 			super.getStrategyGrid().dropMaterial(super.getPos(), materialType, true);
+			super.setMaterial(EMaterialType.NO_MATERIAL);
 			jobFinished();
 		}
 	}


### PR DESCRIPTION
Previously for some workers after dropping off their newly
crafted material they would still be holding it when returning
to the standing position. This fix ensures that after it has been
dropped the material is removed from their person.