### PR TITLE
Prevent pathing loops for idle settlers.

### DIFF
--- a/jsettlers.logic/src/jsettlers/logic/map/newGrid/MainGrid.java
+++ b/jsettlers.logic/src/jsettlers/logic/map/newGrid/MainGrid.java
@@ -1273,7 +1273,7 @@ public final class MainGrid implements Serializable {
 
 				int factor;
 
-				if (!MainGrid.this.isInBounds(currX, currY) || flagsGrid.isBlocked(currX, currY)) {
+				if (!MainGrid.this.isInBounds(currX, currY)) {
 					factor = radius == 1 ? 6 : 2;
 				} else if (!movableGrid.hasNoMovableAt(currX, currY)) {
 					factor = Constants.MOVABLE_FLOCK_TO_DECENTRALIZE_MAX_RADIUS - radius + 1;


### PR DESCRIPTION
Removed the requirement that moveables (settlers) when in the idle state
cannot stop next to a blocked map position.