### PR TITLE
Building construction alignment correction

### DIFF
--- a/jsettlers.graphics/src/jsettlers/graphics/image/SingleImage.java
+++ b/jsettlers.graphics/src/jsettlers/graphics/image/SingleImage.java
@@ -26,7 +26,7 @@ import jsettlers.graphics.reader.ImageMetadata;
  * This is the base for all images.
  * <p>
  * This class interprets the image data in 5-5-5-1-Format. To change the interpretation, it is possible to subclass this class.
- * 
+ *
  * @author michael
  */
 public class SingleImage extends Image implements ImageDataPrivider {
@@ -44,7 +44,7 @@ public class SingleImage extends Image implements ImageDataPrivider {
 
 	/**
 	 * Creates a new image by the given buffer.
-	 * 
+	 *
 	 * @param data
 	 *            The data buffer for the image with an unspecified color format.
 	 * @param width
@@ -67,7 +67,7 @@ public class SingleImage extends Image implements ImageDataPrivider {
 
 	/**
 	 * Creates a new image by linking this images data to the data of the provider.
-	 * 
+	 *
 	 * @param provider
 	 *            The provider.
 	 */
@@ -129,7 +129,7 @@ public class SingleImage extends Image implements ImageDataPrivider {
 
 	/**
 	 * Generates the texture, if needed, and returns the index of that texutre.
-	 * 
+	 *
 	 * @return The gl index or 0 if the texture is not allocated.
 	 */
 	public int getTextureIndex(GLDrawContext gl) {
@@ -178,7 +178,7 @@ public class SingleImage extends Image implements ImageDataPrivider {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see jsettlers.graphics.image.Image#drawAt(go.graphics.GLDrawContext, float, float)
 	 */
 	@Override
@@ -188,7 +188,7 @@ public class SingleImage extends Image implements ImageDataPrivider {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see jsettlers.graphics.image.Image#drawAt(go.graphics.GLDrawContext, float, float, go.graphics.Color)
 	 */
 	@Override
@@ -206,7 +206,7 @@ public class SingleImage extends Image implements ImageDataPrivider {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see jsettlers.graphics.image.Image#draw(go.graphics.GLDrawContext, go.graphics.Color)
 	 */
 	@Override
@@ -300,15 +300,26 @@ public class SingleImage extends Image implements ImageDataPrivider {
 		return (float) height / textureHeight;
 	}
 
-	@Override
-	public void drawAt(GLDrawContext gl, DrawBuffer buffer, float viewX,
-			float viewY, int iColor) {
-		int textureIndex = getTextureIndex(gl);
-		buffer.addImage(textureIndex, viewX + getOffsetX(), viewY
-				- getOffsetY(), viewX + getOffsetX() + width, viewY
-				- getOffsetY() - height, 0, 0, getTextureScaleX(),
-				getTextureScaleY(), iColor);
-	}
+    @Override
+    public void drawAt(GLDrawContext gl, DrawBuffer buffer, float viewX, float viewY, int iColor) {
+        int textureIndex = getTextureIndex(gl);
+
+        float left = viewX + getOffsetX();
+        float top = viewY - getOffsetY();
+
+        buffer.addImage(
+                textureIndex,
+                left,
+                top,
+                left + width,
+                top - height,
+                0,
+                0,
+                getTextureScaleX(),
+                getTextureScaleY(),
+                iColor
+                );
+    }
 
 	protected float convertU(float relativeU) {
 		return relativeU * getTextureScaleX();
@@ -320,7 +331,7 @@ public class SingleImage extends Image implements ImageDataPrivider {
 
 	/**
 	 * Draws a triangle part of this image on the image buffer.
-	 * 
+	 *
 	 * @param gl
 	 *            The context to use
 	 * @param buffer
@@ -337,41 +348,26 @@ public class SingleImage extends Image implements ImageDataPrivider {
 	 * @param v3
 	 * @param activeColor
 	 */
-	public void drawTriangle(GLDrawContext gl, DrawBuffer buffer, float viewX,
-			float viewY, float u1, float v1, float u2, float v2, float u3, float v3, int activeColor) {
-		DrawBuffer.Buffer buffer2 = buffer.getBuffer(getTextureIndex(gl));
-		float left = getOffsetX() + viewX;
-		float top = -getOffsetY() + viewY;
+    public void drawTriangle(GLDrawContext gl, DrawBuffer buffer, float viewX, float viewY,
+            float u1, float v1, float u2, float v2, float u3, float v3, int activeColor) {
+        DrawBuffer.Buffer buffer2 = buffer.getBuffer(getTextureIndex(gl));
+        float left = viewX + getOffsetX();
+        float top = viewY - getOffsetY();
 
-		buffer2.addTriangle(
-			alignCoord( left + u1 * width ),
-			alignCoord( top - v1 * height ),
-			alignCoord( left + u2 * width ),
-			alignCoord( top - v2 * height ),
-			alignCoord( left + u3 * width ),
-			alignCoord( top - v3 * height ),
-			convertU(u1),
-			convertV(v1),
-			convertU(u2),
-			convertV(v2),
-			convertU(u3),
-			convertV(v3),
-			activeColor
-		);
-	}
-
-	/**
-	 * In the draw process sub-integer coordinates can be rounded in unexpected ways that is particularly noticeable when redrawing the
-	 * growing image of a building in the construction phase. By aligning to the nearest integer images can be placed in a more
-	 * predictable and controlled manner.
-	 * @param value the coordinate to be aligned.
-	 * @return an aligned coordinate value.
-	 */
-	private float alignCoord( float value )
-	{
-		//At larger scales the issue is still present to some degree which zoomFactor helps to minimize.
-		//TODO need to find the factor based on the zoom level.
-		float zoomFactor = 1.06f;
-		return (float)((Math.floor( value * zoomFactor )) / zoomFactor);
-	}
+        buffer2.addTriangle(
+                left + (u1 * width),
+                top - (v1 * height),
+                left + (u2 * width),
+                top - (v2 * height),
+                left + (u3 * width),
+                top - (v3 * height),
+                convertU(u1),
+                convertV(v1),
+                convertU(u2),
+                convertV(v2),
+                convertU(u3),
+                convertV(v3),
+                activeColor
+                );
+    }
 }

--- a/jsettlers.graphics/src/jsettlers/graphics/map/MapDrawContext.java
+++ b/jsettlers.graphics/src/jsettlers/graphics/map/MapDrawContext.java
@@ -46,7 +46,7 @@ import jsettlers.graphics.map.geometry.MapCoordinateConverter;
  * given in draw space.
  * <h2>Draw buffer</h2> We hold a draw buffer everyone drawing with the map draw context can use. The buffer should be flushed when drawing one
  * component finished. When the draw buffer is used after a call to end(), the buffer is invalid.
- * 
+ *
  * @author michael
  */
 public final class MapDrawContext implements IGLProvider {
@@ -96,7 +96,7 @@ public final class MapDrawContext implements IGLProvider {
 
 	/**
 	 * Creates a new map context for a given map.
-	 * 
+	 *
 	 * @param map
 	 *            The map.
 	 */
@@ -119,7 +119,7 @@ public final class MapDrawContext implements IGLProvider {
 
 	/**
 	 * Sets the size of the context to width/height.
-	 * 
+	 *
 	 * @param newWidth
 	 *            The width.
 	 * @param newHeight
@@ -131,7 +131,7 @@ public final class MapDrawContext implements IGLProvider {
 
 	/**
 	 * Sets the center of the screen.
-	 * 
+	 *
 	 * @param x
 	 *            X in pixels.
 	 * @param y
@@ -143,7 +143,7 @@ public final class MapDrawContext implements IGLProvider {
 
 	/**
 	 * Begin a new draw session (=> draw a new image). Sets up the gl screen assuming the current viewport is set to (0,0,width,height)
-	 * 
+	 *
 	 * @param gl2
 	 *            The gl context to use.
 	 * @see #end()
@@ -152,12 +152,14 @@ public final class MapDrawContext implements IGLProvider {
 		this.gl = gl2;
 
 		// beginTime = System.nanoTime();
-
 		gl2.glPushMatrix();
+
 		float zoom = screen.getZoom();
-		gl2.glScalef(zoom, zoom, 1);
-		gl2.glTranslatef((int) -this.screen.getLeft() + .5f,
-				(int) -this.screen.getBottom() + .5f, 0);
+		gl2.glScalef(zoom, zoom, 1f);
+
+		float left = screen.getLeft();
+		float bottom = screen.getBottom();
+		gl2.glTranslatef(-left, -bottom, 0);
 	}
 
 	/**
@@ -170,7 +172,7 @@ public final class MapDrawContext implements IGLProvider {
 
 	/**
 	 * Gets the current gl context, of <code>null</code> if it is called outside a gl drawing session.
-	 * 
+	 *
 	 * @return The gl context that was given to {@link #begin(GLDrawContext)}
 	 */
 	@Override
@@ -184,7 +186,7 @@ public final class MapDrawContext implements IGLProvider {
 
 	/**
 	 * Gets the text drawer for the draw context. Use this method instead of the opengl one, because we might override it.
-	 * 
+	 *
 	 * @param size
 	 * @return
 	 */
@@ -194,7 +196,7 @@ public final class MapDrawContext implements IGLProvider {
 
 	/**
 	 * Gets the region of the draw space that is drawn on the screen and therefore rendered.
-	 * 
+	 *
 	 * @return The region displayed on the screen as Rectangle.
 	 */
 	public ScreenPosition getScreen() {
@@ -251,7 +253,7 @@ public final class MapDrawContext implements IGLProvider {
 
 	/**
 	 * Checks two map coordiantes if they are on the map.
-	 * 
+	 *
 	 * @param x
 	 *            The y coordinate in map space.
 	 * @param y
@@ -265,7 +267,7 @@ public final class MapDrawContext implements IGLProvider {
 
 	/**
 	 * Gets the color for a given player.
-	 * 
+	 *
 	 * @param player
 	 *            The player to get the color for.
 	 * @return The color.
@@ -280,7 +282,7 @@ public final class MapDrawContext implements IGLProvider {
 
 	/**
 	 * Gets the converter for the map coordinate system
-	 * 
+	 *
 	 * @return The map coordinate converter.
 	 */
 	public MapCoordinateConverter getConverter() {
@@ -289,7 +291,7 @@ public final class MapDrawContext implements IGLProvider {
 
 	/**
 	 * sets up the gl drawing context to draw a given tile.
-	 * 
+	 *
 	 * @param pos
 	 *            The tile to draw.
 	 */
@@ -310,7 +312,7 @@ public final class MapDrawContext implements IGLProvider {
 
 	/**
 	 * Sets up drawing between two tiles.
-	 * 
+	 *
 	 * @param tile
 	 *            The start tile
 	 * @param destination
@@ -340,7 +342,7 @@ public final class MapDrawContext implements IGLProvider {
 
 	/**
 	 * gets a rect on the screen.
-	 * 
+	 *
 	 * @param x1
 	 *            one x (not ordered)
 	 * @param y1
@@ -374,7 +376,7 @@ public final class MapDrawContext implements IGLProvider {
 
 		/**
 		 * Creates a new IMapArea that contains the points that are in the rectangle on the screen.
-		 * 
+		 *
 		 * @param drawRect
 		 *            The rectangle in draw space
 		 */

--- a/jsettlers.graphics/src/jsettlers/graphics/map/draw/MapObjectDrawer.java
+++ b/jsettlers.graphics/src/jsettlers/graphics/map/draw/MapObjectDrawer.java
@@ -53,7 +53,7 @@ import jsettlers.graphics.sound.SoundManager;
 
 /**
  * This class handles drawing of objects on the map.
- * 
+ *
  * @author michael
  */
 public class MapObjectDrawer {
@@ -85,17 +85,17 @@ public class MapObjectDrawer {
 	 */
 	private static final float TREE_FALLING_SPEED = 1 / 0.001f;
 	/**
-	 * 
+	 *
 	 */
 	private static final int TREE_ROT_IMAGES = 4;
 
 	/**
-	 * 
+	 *
 	 */
 	private static final int TREE_SMALL = 12;
 
 	/**
-	 * 
+	 *
 	 */
 	private static final int TREE_MEDIUM = 11;
 
@@ -152,7 +152,7 @@ public class MapObjectDrawer {
 
 	/**
 	 * Draws a map object at a given position.
-	 * 
+	 *
 	 * @param context
 	 *            The context.
 	 * @param map
@@ -392,7 +392,7 @@ public class MapObjectDrawer {
 
 	/**
 	 * Draws a movable
-	 * 
+	 *
 	 * @param movable
 	 *            The movable.
 	 */
@@ -726,7 +726,7 @@ public class MapObjectDrawer {
 
 	/**
 	 * gets a 0 or a 1.
-	 * 
+	 *
 	 * @param pos
 	 * @return
 	 */
@@ -736,7 +736,7 @@ public class MapObjectDrawer {
 
 	/**
 	 * Draws a player border at a given position.
-	 * 
+	 *
 	 * @param player
 	 *            The player.
 	 */
@@ -772,7 +772,7 @@ public class MapObjectDrawer {
 
 	/**
 	 * Draws a stack
-	 * 
+	 *
 	 * @param context
 	 *            The context to draw with
 	 * @param object
@@ -789,7 +789,7 @@ public class MapObjectDrawer {
 
 	/**
 	 * Draws the stack directly to the screen.
-	 * 
+	 *
 	 * @param glDrawContext
 	 *            The gl context to draw at.
 	 * @param material
@@ -808,7 +808,7 @@ public class MapObjectDrawer {
 
 	/**
 	 * Gets the gray color for a given fog.
-	 * 
+	 *
 	 * @param fogstatus
 	 * @return
 	 */
@@ -818,7 +818,7 @@ public class MapObjectDrawer {
 
 	/**
 	 * Draws a given buildng to the context.
-	 * 
+	 *
 	 * @param context
 	 * @param building
 	 * @param color
@@ -829,6 +829,7 @@ public class MapObjectDrawer {
 
 		float state = building.getStateProgress();
 		float maskState;
+
 		if (state < 0.5f) {
 			maskState = state * 2;
 			for (ImageLink link : type.getBuildImages()) {
@@ -887,7 +888,7 @@ public class MapObjectDrawer {
 
 	/**
 	 * Draws the occupiers of a building
-	 * 
+	 *
 	 * @param x
 	 *            The x coordinate of the building
 	 * @param y
@@ -956,32 +957,39 @@ public class MapObjectDrawer {
 
 	private void drawWithConstructionMask(int x, int y, float maskState,
 			Image unsafeimage, float color) {
-		if (!(unsafeimage instanceof SingleImage)) {
-			return; // should not happen
-		}
-		int height = context.getHeight(x, y);
-		float viewX = context.getConverter().getViewX(x, y, height);
-		float viewY = context.getConverter().getViewY(x, y, height);
-		int iColor = Color.getABGR(color, color, color, 1);
+        if (!(unsafeimage instanceof SingleImage)) {
+            return; // should not happen
+        }
+        int height = context.getHeight(x, y);
+        float viewX = context.getConverter().getViewX(x, y, height);
+        float viewY = context.getConverter().getViewY(x, y, height);
+        int iColor = Color.getABGR(color, color, color, 1);
 
-		SingleImage image = (SingleImage) unsafeimage;
-		// number of tiles in x direction, can be adjusted for performance
-		int tiles = 6;
+        SingleImage image = (SingleImage) unsafeimage;
+        // number of tiles in x direction, can be adjusted for performance
+        int tiles = 6;
 
-		float toplineBottom = 1 - maskState;
-		float toplineTop = Math.max(0, toplineBottom - .1f);
+        float toplineBottom = 1f - maskState;
+        float toplineTop = Math.max(0, toplineBottom - .1f);
 
-		image.drawTriangle(context.getGl(), context.getDrawBuffer(), viewX,
-				viewY, 0, 1, 1, 1, 0, toplineBottom, iColor);
-		image.drawTriangle(context.getGl(), context.getDrawBuffer(), viewX,
-				viewY, 1, 1, 1, toplineBottom, 0, toplineBottom, iColor);
+        GLDrawContext glDrawContext = context.getGl();
+        DrawBuffer drawBuffer = context.getDrawBuffer();
 
-		for (int i = 0; i < tiles; i++) {
-			image.drawTriangle(context.getGl(), context.getDrawBuffer(), viewX,
-					viewY, 1.0f / tiles * i, toplineBottom, 1.0f / tiles
-							* (i + 1), toplineBottom, 1.0f / tiles * (i + .5f),
-					toplineTop, iColor);
-		}
+        image.drawTriangle(glDrawContext, drawBuffer, viewX, viewY, 0, 1, 1, 1, 0, toplineBottom, iColor);
+        image.drawTriangle(glDrawContext, drawBuffer, viewX, viewY, 1f, 1f, 1f, toplineBottom, 0, toplineBottom, iColor);
+        float triangleWidth = 1f / tiles;
+        for (int i = 0; i < tiles; i++) {
+            image.drawTriangle(
+                    glDrawContext,
+                    drawBuffer,
+                    viewX,
+                    viewY,
+                    triangleWidth * i, toplineBottom,
+                    triangleWidth * (i + 1), toplineBottom,
+                    triangleWidth * (i + .5f), toplineTop,
+                    iColor
+                    );
+        }
 	}
 
 	private void drawPlayerableByProgress(int x, int y, int file,


### PR DESCRIPTION
Removing an offset added to the map draw procedure seemed to correct the
issue. Also removed the previous code that was added to correct the
construction image as it is therefore no longer needed.
There is still a slight issue for some zoom levels when the building is at
a certain height on the screen where the points must be misaligned with
the pixels between two draws, there wasn't an obvious fix for this and
it is not frequently seen, it needs a more in depth investigation.