### PR TITLE
feature computer difficulties

### DIFF
--- a/jsettlers.common/src/jsettlers/common/ai/EWhatToDoAiType.java
+++ b/jsettlers.common/src/jsettlers/common/ai/EWhatToDoAiType.java
@@ -3,17 +3,17 @@ package jsettlers.common.ai;
 /**
  * @author codingberlin
  */
-public enum WhatToDoAiType {
+public enum EWhatToDoAiType {
 	ROMAN_VERY_EASY,
 	ROMAN_EASY,
 	ROMAN_HARD,
 	ROMAN_VERY_HARD;
 
 
-	public static final WhatToDoAiType[] values = WhatToDoAiType.values();
+	public static final EWhatToDoAiType[] values = EWhatToDoAiType.values();
 	public static final int NUMBER_OF_AI_TYPES = values.length;
 
-	public static WhatToDoAiType getTypeByIndex(int index) {
+	public static EWhatToDoAiType getTypeByIndex(int index) {
 		return values[index % NUMBER_OF_AI_TYPES];
 	}
 }

--- a/jsettlers.common/src/jsettlers/common/ai/WhatToDoAiType.java
+++ b/jsettlers.common/src/jsettlers/common/ai/WhatToDoAiType.java
@@ -1,0 +1,19 @@
+package jsettlers.common.ai;
+
+/**
+ * @author codingberlin
+ */
+public enum WhatToDoAiType {
+	ROMAN_VERY_EASY,
+	ROMAN_EASY,
+	ROMAN_HARD,
+	ROMAN_VERY_HARD;
+
+
+	public static final WhatToDoAiType[] values = WhatToDoAiType.values();
+	public static final int NUMBER_OF_AI_TYPES = values.length;
+
+	public static WhatToDoAiType getTypeByIndex(int index) {
+		return values[index % NUMBER_OF_AI_TYPES];
+	}
+}

--- a/jsettlers.common/src/jsettlers/common/player/IManaInformation.java
+++ b/jsettlers.common/src/jsettlers/common/player/IManaInformation.java
@@ -1,6 +1,5 @@
 package jsettlers.common.player;
 
-import jsettlers.common.movable.EMovableType;
 import jsettlers.common.movable.ESoldierType;
 
 /**

--- a/jsettlers.graphics/src/jsettlers/graphics/map/controls/original/OriginalControls.java
+++ b/jsettlers.graphics/src/jsettlers/graphics/map/controls/original/OriginalControls.java
@@ -21,7 +21,6 @@ import go.graphics.event.GOModalEventHandler;
 import go.graphics.event.mouse.GODrawEvent;
 import jsettlers.common.map.shapes.MapRectangle;
 import jsettlers.common.player.IInGamePlayer;
-import jsettlers.common.player.IManaInformation;
 import jsettlers.common.position.FloatRectangle;
 import jsettlers.common.position.ShortPoint2D;
 import jsettlers.common.selectable.ISelectionSet;
@@ -68,26 +67,24 @@ public class OriginalControls implements IControls {
 
 		btnChat = new Button(
 				new ExecutableAction() {
-					MessageContent messageContent =
-							new MessageContent(
-									"This is not yet implemented.",
-									"Cancel",
-									new ExecutableAction() {
-										@Override
-										public void execute() {
-											mainPanel.setContent(ContentType.BUILD_NORMAL);
-											btnChat.setActive(false);
-										}
-									},
-									"Ok",
-									new ExecutableAction() {
-										@Override
-										public void execute() {
-											mainPanel.setContent(ContentType.BUILD_NORMAL);
-											btnChat.setActive(false);
-										}
-									}
-							);
+					MessageContent messageContent = new MessageContent(
+							"This is not yet implemented.",
+							"Cancel",
+							new ExecutableAction() {
+						@Override
+						public void execute() {
+							mainPanel.setContent(ContentType.BUILD_NORMAL);
+							btnChat.setActive(false);
+						}
+					},
+							"Ok",
+							new ExecutableAction() {
+						@Override
+						public void execute() {
+							mainPanel.setContent(ContentType.BUILD_NORMAL);
+							btnChat.setActive(false);
+						}
+					});
 
 					@Override
 					public void execute() {
@@ -115,14 +112,12 @@ public class OriginalControls implements IControls {
 				layoutProperties.miniMap.RIGHT_DECORATION_LEFT,
 				0,
 				layoutProperties.miniMap.RIGHT_DECORATION_LEFT + layoutProperties.RIGHT_DECORATION_WIDTH,
-				layoutProperties.MAIN_PANEL_TOP
-				);
+				layoutProperties.MAIN_PANEL_TOP);
 
 		return panel;
 	}
 
-	private void addMiniMap(UIPanel panel)
-	{
+	private void addMiniMap(UIPanel panel) {
 		MiniMapLayoutProperties miniMap = layoutProperties.miniMap;
 		UIPanel minimapbg_left = new UIPanel();
 		minimapbg_left.setBackground(miniMap.LEFT_DECORATION);
@@ -131,29 +126,25 @@ public class OriginalControls implements IControls {
 				miniMap.BUTTON_CHAT_LEFT,
 				miniMap.BUTTON_CHAT_TOP - miniMap.BUTTON_HEIGHT,
 				miniMap.BUTTON_CHAT_LEFT + miniMap.BUTTON_WIDTH,
-				miniMap.BUTTON_CHAT_TOP
-				);
+				miniMap.BUTTON_CHAT_TOP);
 		minimapbg_left.addChild(
 				new MinimapOccupiedButton(minimapSettings),
 				miniMap.BUTTON_FEATURES_LEFT,
 				miniMap.BUTTON_FEATURES_TOP - miniMap.BUTTON_HEIGHT,
 				miniMap.BUTTON_FEATURES_LEFT + miniMap.BUTTON_WIDTH,
-				miniMap.BUTTON_FEATURES_TOP
-				);
+				miniMap.BUTTON_FEATURES_TOP);
 		minimapbg_left.addChild(
 				new MinimapSettlersButton(minimapSettings),
 				miniMap.BUTTON_SETTLERS_LEFT,
 				miniMap.BUTTON_SETTLERS_TOP - miniMap.BUTTON_HEIGHT,
 				miniMap.BUTTON_SETTLERS_LEFT + miniMap.BUTTON_WIDTH,
-				miniMap.BUTTON_SETTLERS_TOP
-				);
+				miniMap.BUTTON_SETTLERS_TOP);
 		minimapbg_left.addChild(
 				new MinimapBuildingButton(minimapSettings),
 				miniMap.BUTTON_BUILDINGS_LEFT,
 				miniMap.BUTTON_BUILDINGS_TOP - miniMap.BUTTON_HEIGHT,
 				miniMap.BUTTON_BUILDINGS_LEFT + miniMap.BUTTON_WIDTH,
-				miniMap.BUTTON_BUILDINGS_TOP
-				);
+				miniMap.BUTTON_BUILDINGS_TOP);
 
 		UIPanel minimapbg_right = new UIPanel();
 		minimapbg_right.setBackground(miniMap.RIGHT_DECORATION);
@@ -220,10 +211,8 @@ public class OriginalControls implements IControls {
 
 	@Override
 	public Action getActionFor(UIPoint position, boolean selecting) {
-		float relativex =
-				(float) position.getX() / this.uiBase.getPosition().getWidth();
-		float relativey =
-				(float) position.getY() / this.uiBase.getPosition().getHeight();
+		float relativex = (float) position.getX() / this.uiBase.getPosition().getWidth();
+		float relativey = (float) position.getY() / this.uiBase.getPosition().getHeight();
 		Action action;
 		if (minimap != null && relativey > layoutProperties.MAIN_PANEL_TOP && getMinimapOffset(position.getY()) < position.getX()) {
 			action = getForMinimap(relativex, relativey, selecting);
@@ -242,15 +231,12 @@ public class OriginalControls implements IControls {
 
 	private Action getForMinimap(float relativex, float relativey,
 			boolean selecting) {
-		float minimapx =
-				(relativex - layoutProperties.miniMap.MAP_LEFT)
-						/ layoutProperties.miniMap.MAP_WIDTH;
-		float minimapy =
-				((relativey - layoutProperties.MAIN_PANEL_TOP)
-						/ (1 - layoutProperties.MAIN_PANEL_TOP) - layoutProperties.miniMap.MAP_BOTTOM)
-						/ layoutProperties.miniMap.MAP_HEIGHT;
-		ShortPoint2D clickPosition =
-				minimap.getClickPositionIfOnMap(minimapx, minimapy);
+		float minimapx = (relativex - layoutProperties.miniMap.MAP_LEFT)
+				/ layoutProperties.miniMap.MAP_WIDTH;
+		float minimapy = ((relativey - layoutProperties.MAIN_PANEL_TOP)
+				/ (1 - layoutProperties.MAIN_PANEL_TOP) - layoutProperties.miniMap.MAP_BOTTOM)
+				/ layoutProperties.miniMap.MAP_HEIGHT;
+		ShortPoint2D clickPosition = minimap.getClickPositionIfOnMap(minimapx, minimapy);
 		if (clickPosition != null) {
 			if (selecting) {
 				return new PointAction(EActionType.PAN_TO, clickPosition);
@@ -264,10 +250,8 @@ public class OriginalControls implements IControls {
 
 	@Override
 	public String getDescriptionFor(UIPoint position) {
-		float relativex =
-				(float) position.getX() / this.uiBase.getPosition().getWidth();
-		float relativey =
-				(float) position.getY() / this.uiBase.getPosition().getHeight();
+		float relativex = (float) position.getX() / this.uiBase.getPosition().getWidth();
+		float relativey = (float) position.getY() / this.uiBase.getPosition().getHeight();
 		return uiBase.getDescription(relativex, relativey);
 	}
 
@@ -352,7 +336,7 @@ public class OriginalControls implements IControls {
 				if (mainPanel.isSelectionActive()) {
 					mainPanel.setContent(ContentType.EMPTY);
 				}
-			}// else: nothing to do
+			} // else: nothing to do
 		} else {
 			lastSelectionWasNull = false;
 

--- a/jsettlers.graphics/src/jsettlers/graphics/map/controls/original/panel/MainPanel.java
+++ b/jsettlers.graphics/src/jsettlers/graphics/map/controls/original/panel/MainPanel.java
@@ -19,7 +19,6 @@ import jsettlers.common.images.OriginalImageLink;
 import jsettlers.common.map.IGraphicsGrid;
 import jsettlers.common.map.shapes.MapRectangle;
 import jsettlers.common.player.IInGamePlayer;
-import jsettlers.common.player.IManaInformation;
 import jsettlers.common.position.ShortPoint2D;
 import jsettlers.graphics.action.Action;
 import jsettlers.graphics.action.ActionFireable;
@@ -70,30 +69,28 @@ public class MainPanel extends UIPanel {
 			new TabButton(ContentType.PRODUCTION, BUTTONS_FILE, 243, 255, ""),
 	};
 
-	private final MessageContent quitPrompt =
-			new MessageContent(
-					Labels.getString("game-quit"),
-					Labels.getString("game-quit-cancel"),
-					new ExecutableAction() {
-						@Override
-						public void execute() {
-							setContent(ContentType.BUILD_NORMAL);
-							btnSystem.setActive(false);
-						}
-					},
-					Labels.getString("game-quit-ok"),
-					new Action(EActionType.EXIT)
-			) {
+	private final MessageContent quitPrompt = new MessageContent(
+			Labels.getString("game-quit"),
+			Labels.getString("game-quit-cancel"),
+			new ExecutableAction() {
 				@Override
-				public void contentShowing(ActionFireable actionFireable) {
-					btnSystem.setActive(true);
-				}
-
-				@Override
-				public void contentHiding(ActionFireable actionFireable, AbstractContentProvider nextContent) {
+				public void execute() {
+					setContent(ContentType.BUILD_NORMAL);
 					btnSystem.setActive(false);
 				}
-			};
+			},
+			Labels.getString("game-quit-ok"),
+			new Action(EActionType.EXIT)) {
+		@Override
+		public void contentShowing(ActionFireable actionFireable) {
+			btnSystem.setActive(true);
+		}
+
+		@Override
+		public void contentHiding(ActionFireable actionFireable, AbstractContentProvider nextContent) {
+			btnSystem.setActive(false);
+		}
+	};
 
 	private final Button btnSystem = new TabButton(quitPrompt,
 			new OriginalImageLink(EImageLinkType.GUI, BUTTONS_FILE, 93, 0),
@@ -103,6 +100,7 @@ public class MainPanel extends UIPanel {
 	private final Button btnSwords = new TabButton(ContentType.EMPTY, BUTTONS_FILE, 114, 102, "");
 	private final Button btnSignPost = new TabButton(ContentType.EMPTY, BUTTONS_FILE, 117, 105, "");
 	private final Button btnPots = new TabButton(ContentType.EMPTY, BUTTONS_FILE, 120, 108, "");
+
 	{
 		btnScroll.setActive(true);
 		btnSwords.setActive(true);
@@ -244,12 +242,10 @@ public class MainPanel extends UIPanel {
 				constants.SYSTEM_BUTTON_LEFT,
 				constants.SYSTEM_BUTTON_BOTTOM,
 				constants.SYSTEM_BUTTON_RIGHT,
-				constants.SYSTEM_BUTTON_TOP
-				);
+				constants.SYSTEM_BUTTON_TOP);
 	}
 
-	private void addLowerTabBar()
-	{
+	private void addLowerTabBar() {
 		UIPanel lowerTabBar = new UIPanel();
 		Button[] buttons = new Button[] { btnScroll, btnSwords, btnSignPost, btnPots };
 		int i = 0;
@@ -284,7 +280,8 @@ public class MainPanel extends UIPanel {
 			setContent(new MessageContent(
 					Labels.getString("really_destroy_building"),
 					Labels.getName(EActionType.DESTROY), new Action(
-							EActionType.DESTROY), Labels.getString("abort"),
+							EActionType.DESTROY),
+					Labels.getString("abort"),
 					new Action(EActionType.ABORT)) {
 				@Override
 				public boolean isForSelection() {
@@ -316,7 +313,7 @@ public class MainPanel extends UIPanel {
 		this.grid = grid;
 		displayCenter = new ShortPoint2D(screenArea.getLineStartX(screenArea.getLines() / 2)
 				+ screenArea.getLineLength() / 2, screenArea
-				.getLineY(screenArea.getLines() / 2));
+						.getLineY(screenArea.getLines() / 2));
 		sendMapPositionChange();
 	}
 

--- a/jsettlers.graphics/src/jsettlers/graphics/startscreen/interfaces/FakeMapGame.java
+++ b/jsettlers.graphics/src/jsettlers/graphics/startscreen/interfaces/FakeMapGame.java
@@ -17,9 +17,7 @@ package jsettlers.graphics.startscreen.interfaces;
 import jsettlers.common.map.IGraphicsGrid;
 import jsettlers.common.material.EMaterialType;
 import jsettlers.common.movable.EMovableType;
-import jsettlers.common.movable.ESoldierType;
 import jsettlers.common.player.IInGamePlayer;
-import jsettlers.common.player.IManaInformation;
 import jsettlers.common.statistics.IStatisticable;
 
 /**
@@ -67,7 +65,8 @@ public class FakeMapGame implements IStartedGame {
 		return new NullStatistics();
 	}
 
-	@Override public IInGamePlayer getInGamePlayer() {
+	@Override
+	public IInGamePlayer getInGamePlayer() {
 		return null;
 	}
 

--- a/jsettlers.logic/src/jsettlers/ai/army/WinnerGeneral.java
+++ b/jsettlers.logic/src/jsettlers/ai/army/WinnerGeneral.java
@@ -16,9 +16,6 @@
  */
 package jsettlers.ai.army;
 
-import java.util.List;
-import java.util.Vector;
-
 import jsettlers.ai.highlevel.AiStatistics;
 import jsettlers.common.buildings.EBuildingType;
 import jsettlers.common.movable.EMovableType;
@@ -31,16 +28,24 @@ import jsettlers.logic.map.grid.movable.MovableGrid;
 import jsettlers.logic.player.Player;
 import jsettlers.network.client.interfaces.ITaskScheduler;
 
+import java.util.List;
+import java.util.Vector;
+
 /**
- * This general is named looser because his attacks are no serious danger because he sends no more solders than his opponent has, which gives his
- * opponent the chance to defeat. - When any enemy solder enters his land, he sends all his solders to it to defeat. - He keeps a 10 swordsmen buffer
- * in his land to occupy own towers - He uses the rest of the troops to attack when the attack group minimum size is 10 and the opponent have less
- * soldiers. - He sends at minimum 20 soldiers and maximum as many soldiers as his opoonent has - He preferes bowmens but takes 10 near combat
- * soldiers at minimum to attack in order to occupy enemy towers.
+ * This general is named winner because his attacks and defence should be very hard for human enemies. This should be realized by creating locally
+ * superiority. (You can kill 200 bowmen with just 100 bowmen if you fight 100 vs 20 in loops. This general should lay the focus on some swordsmen
+ * to occupy own towers, 20 spearmen to defeat rushes and the rest only bowmen because in mass this is the strongest military unit. It upgrades
+ * bowmen first because this is the main unit and the 20 defeating spearmen defeats with lv1 as well. This general should store bows until level3
+ * is reached to get as many level3 bowmen as posibble.
+ * TODO: store bows until level3 is reached
+ * TODO: just produce some swords, 20 spearmen and the rest bows
+ * TODO: group soldiers in direction of enemy groups to defeat them
+ * TODO: group soldiers in direction of enemy groups to attack them
+ * TODO: introduce rush defency by early weaponsmith when enemy rushes
  *
  * @author codingberlin
  */
-public class LooserGeneral implements ArmyGeneral {
+public class WinnerGeneral implements ArmyGeneral {
 	private static final byte MIN_ATTACKER_SIZE = 20;
 	private static final byte SWORDSMEN_BUFFER_TO_OCCUPY_TOWERS = 10;
 	private static final byte MIN_NEAR_COMBAT_SOLDIERS = 10;
@@ -50,7 +55,7 @@ public class LooserGeneral implements ArmyGeneral {
 	private final ITaskScheduler taskScheduler;
 	private final MovableGrid movableGrid;
 
-	public LooserGeneral(AiStatistics aiStatistics, Player player, MovableGrid movableGrid, ITaskScheduler taskScheduler) {
+	public WinnerGeneral(AiStatistics aiStatistics, Player player, MovableGrid movableGrid, ITaskScheduler taskScheduler) {
 		this.aiStatistics = aiStatistics;
 		this.player = player;
 		this.taskScheduler = taskScheduler;
@@ -72,9 +77,9 @@ public class LooserGeneral implements ArmyGeneral {
 
 	@Override
 	public void levyUnits() {
-		if (!upgradeSoldiers(ESoldierType.SWORDSMAN))
+		if (!upgradeSoldiers(ESoldierType.BOWMAN))
 			if (!upgradeSoldiers(ESoldierType.PIKEMAN))
-				upgradeSoldiers(ESoldierType.BOWMAN);
+				upgradeSoldiers(ESoldierType.SWORDSMAN);
 	}
 
 	private boolean upgradeSoldiers(ESoldierType type) {

--- a/jsettlers.logic/src/jsettlers/ai/economy/EconomyMinister.java
+++ b/jsettlers.logic/src/jsettlers/ai/economy/EconomyMinister.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2015
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *******************************************************************************/
+package jsettlers.ai.economy;
+
+import jsettlers.common.buildings.EBuildingType;
+
+import java.util.List;
+
+/**
+ * @author codingberlin
+ */
+public interface EconomyMinister {
+
+	int getNumberOfParallelConstructionSides();
+
+	List<EBuildingType> getBuildingsToBuild();
+
+}

--- a/jsettlers.logic/src/jsettlers/ai/economy/LooserEconomyMinister.java
+++ b/jsettlers.logic/src/jsettlers/ai/economy/LooserEconomyMinister.java
@@ -1,0 +1,174 @@
+/*******************************************************************************
+ * Copyright (c) 2015
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *******************************************************************************/
+package jsettlers.ai.economy;
+
+import jsettlers.common.buildings.EBuildingType;
+
+import java.util.List;
+import java.util.Vector;
+
+import static jsettlers.common.buildings.EBuildingType.*;
+
+/**
+ * This economy minister is not well optimized. It is slowed down at all by just building 5 lumberjacks and 3 stonecutters. It one late and one
+ * very late wine grower so that it gets late level upgrades. It builds 10 construction sides in parallel which makes it hard to react flexible to
+ * lack of settlers which will slow down the computer player as well.
+ *
+ * @author codingberlin
+ */
+public class LooserEconomyMinister implements EconomyMinister {
+
+	private final List<EBuildingType> buildingsToBuild;
+
+	public LooserEconomyMinister() {
+		buildingsToBuild = new Vector<EBuildingType>();
+		initializeBuildingsToBuild();
+	}
+
+	private void initializeBuildingsToBuild() {
+		buildingsToBuild.add(LUMBERJACK);
+		buildingsToBuild.add(LUMBERJACK);
+		buildingsToBuild.add(SAWMILL);
+		buildingsToBuild.add(LUMBERJACK);
+		buildingsToBuild.add(FORESTER);
+		buildingsToBuild.add(STONECUTTER);
+		buildingsToBuild.add(LUMBERJACK);
+		buildingsToBuild.add(FORESTER);
+		buildingsToBuild.add(LUMBERJACK);
+		buildingsToBuild.add(SAWMILL);
+		buildingsToBuild.add(FORESTER);
+		buildingsToBuild.add(STONECUTTER);
+		buildingsToBuild.add(STONECUTTER);
+		buildingsToBuild.add(FARM);
+		buildingsToBuild.add(FARM);
+		buildingsToBuild.add(FARM);
+		buildingsToBuild.add(COALMINE);
+		buildingsToBuild.add(IRONMINE);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(BARRACK);
+		buildingsToBuild.add(WINEGROWER);
+		buildingsToBuild.add(MILL);
+		buildingsToBuild.add(BAKER);
+		buildingsToBuild.add(WATERWORKS);
+		buildingsToBuild.add(PIG_FARM);
+		buildingsToBuild.add(SLAUGHTERHOUSE);
+		buildingsToBuild.add(TEMPLE);
+		buildingsToBuild.add(COALMINE);
+		buildingsToBuild.add(IRONMINE);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(BAKER);
+		buildingsToBuild.add(WINEGROWER);
+		buildingsToBuild.add(COALMINE);
+		buildingsToBuild.add(IRONMINE);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(BAKER);
+		buildingsToBuild.add(COALMINE);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(TEMPLE);
+		buildingsToBuild.add(FARM);
+		buildingsToBuild.add(FARM);
+		buildingsToBuild.add(FARM);
+		buildingsToBuild.add(COALMINE);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(BIG_TEMPLE);
+		buildingsToBuild.add(WATERWORKS);
+		buildingsToBuild.add(FARM);
+		buildingsToBuild.add(FARM);
+		buildingsToBuild.add(FARM);
+		buildingsToBuild.add(COALMINE);
+		buildingsToBuild.add(IRONMINE);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(BARRACK);
+		buildingsToBuild.add(COALMINE);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(FISHER);
+		buildingsToBuild.add(COALMINE);
+		buildingsToBuild.add(GOLDMINE);
+		buildingsToBuild.add(GOLDMELT);
+		buildingsToBuild.add(PIG_FARM);
+		buildingsToBuild.add(MILL);
+		buildingsToBuild.add(BAKER);
+		buildingsToBuild.add(COALMINE);
+		buildingsToBuild.add(IRONMINE);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(COALMINE);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(BAKER);
+		buildingsToBuild.add(WATERWORKS);
+		buildingsToBuild.add(PIG_FARM);
+		buildingsToBuild.add(BAKER);
+		buildingsToBuild.add(COALMINE);
+		buildingsToBuild.add(IRONMINE);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(BARRACK);
+		buildingsToBuild.add(COALMINE);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(FARM);
+		buildingsToBuild.add(FARM);
+		buildingsToBuild.add(FARM);
+		buildingsToBuild.add(COALMINE);
+		buildingsToBuild.add(IRONMINE);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(COALMINE);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(MILL);
+		buildingsToBuild.add(BAKER);
+		buildingsToBuild.add(WATERWORKS);
+		buildingsToBuild.add(PIG_FARM);
+		buildingsToBuild.add(SLAUGHTERHOUSE);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(BAKER);
+		buildingsToBuild.add(WATERWORKS);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(BAKER);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+	}
+
+	@Override
+	public int getNumberOfParallelConstructionSides() {
+		return 10;
+	}
+
+	@Override public List<EBuildingType> getBuildingsToBuild() {
+		return buildingsToBuild;
+	}
+
+	@Override
+	public String toString() {
+		return this.getClass().getName();
+	}
+}

--- a/jsettlers.logic/src/jsettlers/ai/economy/WinnerEconomyMinister.java
+++ b/jsettlers.logic/src/jsettlers/ai/economy/WinnerEconomyMinister.java
@@ -1,0 +1,179 @@
+/*******************************************************************************
+ * Copyright (c) 2015
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *******************************************************************************/
+package jsettlers.ai.economy;
+
+import jsettlers.common.buildings.EBuildingType;
+
+import java.util.List;
+import java.util.Vector;
+
+import static jsettlers.common.buildings.EBuildingType.*;
+import static jsettlers.common.buildings.EBuildingType.IRONMELT;
+import static jsettlers.common.buildings.EBuildingType.WEAPONSMITH;
+
+/**
+ * This economy minister is as optimized as possible to create fast and many level 3 soldiers with high combat strength. It builds a longterm economy
+ * with 8 lumberjacks first, then mana, food, weapons and gold economy.
+ *
+ * @author codingberlin
+ */
+public class WinnerEconomyMinister implements EconomyMinister {
+
+	private final List<EBuildingType> buildingsToBuild;
+
+	public WinnerEconomyMinister() {
+		buildingsToBuild = new Vector<EBuildingType>();
+		initializeBuildingsToBuild();
+	}
+
+	private void initializeBuildingsToBuild() {
+		buildingsToBuild.add(LUMBERJACK);
+		buildingsToBuild.add(LUMBERJACK);
+		buildingsToBuild.add(SAWMILL);
+		buildingsToBuild.add(LUMBERJACK);
+		buildingsToBuild.add(FORESTER);
+		buildingsToBuild.add(STONECUTTER);
+		buildingsToBuild.add(LUMBERJACK);
+		buildingsToBuild.add(FORESTER);
+		buildingsToBuild.add(LUMBERJACK);
+		buildingsToBuild.add(SAWMILL);
+		buildingsToBuild.add(LUMBERJACK);
+		buildingsToBuild.add(FORESTER);
+		buildingsToBuild.add(STONECUTTER);
+		buildingsToBuild.add(LUMBERJACK);
+		buildingsToBuild.add(LUMBERJACK);
+		buildingsToBuild.add(SAWMILL);
+		buildingsToBuild.add(FORESTER);
+		buildingsToBuild.add(STONECUTTER);
+		buildingsToBuild.add(STONECUTTER);
+		buildingsToBuild.add(STONECUTTER);
+		buildingsToBuild.add(WINEGROWER);
+		buildingsToBuild.add(WINEGROWER);
+		buildingsToBuild.add(WINEGROWER);
+		buildingsToBuild.add(WINEGROWER);
+		buildingsToBuild.add(FARM);
+		buildingsToBuild.add(FARM);
+		buildingsToBuild.add(FARM);
+		buildingsToBuild.add(TEMPLE);
+		buildingsToBuild.add(TEMPLE);
+		buildingsToBuild.add(TEMPLE);
+		buildingsToBuild.add(TEMPLE);
+		buildingsToBuild.add(COALMINE);
+		buildingsToBuild.add(IRONMINE);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(BARRACK);
+		buildingsToBuild.add(MILL);
+		buildingsToBuild.add(BAKER);
+		buildingsToBuild.add(WATERWORKS);
+		buildingsToBuild.add(PIG_FARM);
+		buildingsToBuild.add(SLAUGHTERHOUSE);
+		buildingsToBuild.add(COALMINE);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(BIG_TEMPLE);
+		buildingsToBuild.add(BAKER);
+		buildingsToBuild.add(BAKER);
+		buildingsToBuild.add(WATERWORKS);
+		buildingsToBuild.add(COALMINE);
+		buildingsToBuild.add(IRONMINE);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(COALMINE);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(FARM);
+		buildingsToBuild.add(FARM);
+		buildingsToBuild.add(FARM);
+		buildingsToBuild.add(COALMINE);
+		buildingsToBuild.add(IRONMINE);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(BARRACK);
+		buildingsToBuild.add(COALMINE);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(FISHER);
+		buildingsToBuild.add(COALMINE);
+		buildingsToBuild.add(GOLDMINE);
+		buildingsToBuild.add(GOLDMELT);
+		buildingsToBuild.add(PIG_FARM);
+		buildingsToBuild.add(MILL);
+		buildingsToBuild.add(BAKER);
+		buildingsToBuild.add(COALMINE);
+		buildingsToBuild.add(IRONMINE);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(COALMINE);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(BAKER);
+		buildingsToBuild.add(WATERWORKS);
+		buildingsToBuild.add(PIG_FARM);
+		buildingsToBuild.add(BAKER);
+		buildingsToBuild.add(COALMINE);
+		buildingsToBuild.add(IRONMINE);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(BARRACK);
+		buildingsToBuild.add(COALMINE);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(FARM);
+		buildingsToBuild.add(FARM);
+		buildingsToBuild.add(FARM);
+		buildingsToBuild.add(COALMINE);
+		buildingsToBuild.add(IRONMINE);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(COALMINE);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(MILL);
+		buildingsToBuild.add(BAKER);
+		buildingsToBuild.add(WATERWORKS);
+		buildingsToBuild.add(PIG_FARM);
+		buildingsToBuild.add(SLAUGHTERHOUSE);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(BAKER);
+		buildingsToBuild.add(WATERWORKS);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(BAKER);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+		buildingsToBuild.add(IRONMELT);
+		buildingsToBuild.add(WEAPONSMITH);
+	}
+
+	@Override
+	public int getNumberOfParallelConstructionSides() {
+		return 5;
+	}
+
+	@Override public List<EBuildingType> getBuildingsToBuild() {
+		return buildingsToBuild;
+	}
+
+	@Override
+	public String toString() {
+		return this.getClass().getName();
+	}
+}

--- a/jsettlers.logic/src/jsettlers/ai/highlevel/AiExecutor.java
+++ b/jsettlers.logic/src/jsettlers/ai/highlevel/AiExecutor.java
@@ -17,8 +17,6 @@ package jsettlers.ai.highlevel;
 import java.util.ArrayList;
 import java.util.List;
 
-import jsettlers.ai.army.LooserGeneral;
-import jsettlers.ai.economy.WinnerEconomyMinister;
 import jsettlers.common.logging.StatisticsStopWatch;
 import jsettlers.common.logging.StopWatch;
 import jsettlers.logic.map.grid.MainGrid;

--- a/jsettlers.logic/src/jsettlers/ai/highlevel/AiExecutor.java
+++ b/jsettlers.logic/src/jsettlers/ai/highlevel/AiExecutor.java
@@ -32,16 +32,17 @@ import jsettlers.network.synchronic.timer.INetworkTimerable;
 public class AiExecutor implements INetworkTimerable {
 
 	private final List<IWhatToDoAi> whatToDoAis;
-	AiStatistics aiStatistics;
-	StopWatch stopWatch = new StatisticsStopWatch();
-	StopWatch stopWatch2 = new StatisticsStopWatch();
+	private final AiStatistics aiStatistics;
+	private final StopWatch stopWatch = new StatisticsStopWatch();
+	private final StopWatch stopWatch2 = new StatisticsStopWatch();
 
 	public AiExecutor(PlayerSetting[] playerSettings, MainGrid mainGrid, ITaskScheduler taskScheduler) {
 		aiStatistics = new AiStatistics(mainGrid);
 		this.whatToDoAis = new ArrayList<IWhatToDoAi>();
 		WhatToDoAiFactory aiFactory = new WhatToDoAiFactory();
 		for (byte playerId = 0; playerId < playerSettings.length; playerId++) {
-			if (playerSettings[playerId].isAi()) {
+			PlayerSetting playerSetting = playerSettings[playerId];
+			if (playerSetting.isAvailable() && playerSetting.isAi()) {
 				whatToDoAis.add(aiFactory.buildWhatToDoAi(
 						playerSettings[playerId].getAiType(),
 						aiStatistics,

--- a/jsettlers.logic/src/jsettlers/ai/highlevel/WhatToDoAi.java
+++ b/jsettlers.logic/src/jsettlers/ai/highlevel/WhatToDoAi.java
@@ -17,11 +17,8 @@ package jsettlers.ai.highlevel;
 import static jsettlers.common.buildings.EBuildingType.BAKER;
 import static jsettlers.common.buildings.EBuildingType.BARRACK;
 import static jsettlers.common.buildings.EBuildingType.BIG_LIVINGHOUSE;
-import static jsettlers.common.buildings.EBuildingType.BIG_TEMPLE;
 import static jsettlers.common.buildings.EBuildingType.COALMINE;
 import static jsettlers.common.buildings.EBuildingType.FARM;
-import static jsettlers.common.buildings.EBuildingType.FISHER;
-import static jsettlers.common.buildings.EBuildingType.FORESTER;
 import static jsettlers.common.buildings.EBuildingType.GOLDMELT;
 import static jsettlers.common.buildings.EBuildingType.GOLDMINE;
 import static jsettlers.common.buildings.EBuildingType.IRONMELT;
@@ -38,7 +35,6 @@ import static jsettlers.common.buildings.EBuildingType.STONECUTTER;
 import static jsettlers.common.buildings.EBuildingType.TEMPLE;
 import static jsettlers.common.buildings.EBuildingType.TOOLSMITH;
 import static jsettlers.common.buildings.EBuildingType.TOWER;
-import static jsettlers.common.buildings.EBuildingType.WATERWORKS;
 import static jsettlers.common.buildings.EBuildingType.WEAPONSMITH;
 import static jsettlers.common.buildings.EBuildingType.WINEGROWER;
 import static jsettlers.common.material.EMaterialType.GOLD;
@@ -46,7 +42,11 @@ import static jsettlers.common.material.EMaterialType.HAMMER;
 import static jsettlers.common.material.EMaterialType.PICK;
 import static jsettlers.logic.constants.Constants.TOWER_SEARCH_RADIUS;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import jsettlers.ai.army.ArmyGeneral;
 import jsettlers.ai.construction.BestConstructionPositionFinderFactory;
@@ -66,10 +66,10 @@ import jsettlers.logic.movable.Movable;
 import jsettlers.network.client.interfaces.ITaskScheduler;
 
 /**
- * This WhatToDoAi is a high level KI. It delegates the decision which building is build next to its economy minister. However this WhatToDoAi
- * takes care against lack of settlers and it builds a toolsmith when needed but as late as possible. Furthermore it builds towers continously to
- * spread the land. It destroys not needed living houses and stonecutters to get back building materials. Which soldiers to levy and to command the
- * soldiers is delegated to its armay general.
+ * This WhatToDoAi is a high level KI. It delegates the decision which building is build next to its economy minister. However this WhatToDoAi takes
+ * care against lack of settlers and it builds a toolsmith when needed but as late as possible. Furthermore it builds towers continously to spread the
+ * land. It destroys not needed living houses and stonecutters to get back building materials. Which soldiers to levy and to command the soldiers is
+ * delegated to its armay general.
  *
  * @author codingberling
  */
@@ -91,8 +91,7 @@ public class WhatToDoAi implements IWhatToDoAi {
 	private final EconomyMinister economyMinister;
 
 	public WhatToDoAi(byte playerId, AiStatistics aiStatistics, EconomyMinister economyMinister, ArmyGeneral armyGeneral, MainGrid mainGrid,
-			ITaskScheduler
-			taskScheduler) {
+			ITaskScheduler taskScheduler) {
 		this.playerId = playerId;
 		this.mainGrid = mainGrid;
 		this.taskScheduler = taskScheduler;
@@ -168,26 +167,27 @@ public class WhatToDoAi implements IWhatToDoAi {
 		}
 
 		// destroy livinghouses
-		int numberOfFreeBeds = aiStatistics.getNumberOfBuildingTypeForPlayer(EBuildingType.SMALL_LIVINGHOUSE, playerId) * NUMBER_OF_SMALL_LIVINGHOUSE_BEDS
+		int numberOfFreeBeds = aiStatistics.getNumberOfBuildingTypeForPlayer(EBuildingType.SMALL_LIVINGHOUSE, playerId)
+				* NUMBER_OF_SMALL_LIVINGHOUSE_BEDS
 				+ aiStatistics.getNumberOfBuildingTypeForPlayer(EBuildingType.MEDIUM_LIVINGHOUSE, playerId) * NUMBER_OF_MEDIUM_LIVINGHOUSE_BEDS
 				+ aiStatistics.getNumberOfBuildingTypeForPlayer(EBuildingType.BIG_LIVINGHOUSE, playerId) * NUMBER_OF_BIG_LIVINGHOUSE_BEDS
 				- aiStatistics.getMovablePositionsByTypeForPlayer(EMovableType.BEARER, playerId).size();
-		if (numberOfFreeBeds >= NUMBER_OF_SMALL_LIVINGHOUSE_BEDS + 1 && aiStatistics.getNumberOfBuildingTypeForPlayer(EBuildingType
-				.SMALL_LIVINGHOUSE, playerId) > 0) {
+		if (numberOfFreeBeds >= NUMBER_OF_SMALL_LIVINGHOUSE_BEDS + 1
+				&& aiStatistics.getNumberOfBuildingTypeForPlayer(EBuildingType.SMALL_LIVINGHOUSE, playerId) > 0) {
 			taskScheduler.scheduleTask(new DestroyBuildingGuiTask(playerId,
 					aiStatistics.getBuildingPositionsOfTypeForPlayer(EBuildingType.SMALL_LIVINGHOUSE, playerId).get(0)));
-		} else if (numberOfFreeBeds >= NUMBER_OF_MEDIUM_LIVINGHOUSE_BEDS + 1 && aiStatistics.getNumberOfBuildingTypeForPlayer(EBuildingType
-				.MEDIUM_LIVINGHOUSE, playerId) > 0) {
+		} else if (numberOfFreeBeds >= NUMBER_OF_MEDIUM_LIVINGHOUSE_BEDS + 1
+				&& aiStatistics.getNumberOfBuildingTypeForPlayer(EBuildingType.MEDIUM_LIVINGHOUSE, playerId) > 0) {
 			taskScheduler.scheduleTask(new DestroyBuildingGuiTask(playerId,
 					aiStatistics.getBuildingPositionsOfTypeForPlayer(EBuildingType.MEDIUM_LIVINGHOUSE, playerId).get(0)));
-		} else if (numberOfFreeBeds >= NUMBER_OF_BIG_LIVINGHOUSE_BEDS + 1 && aiStatistics.getNumberOfBuildingTypeForPlayer(EBuildingType
-				.BIG_LIVINGHOUSE, playerId) > 0) {
+		} else if (numberOfFreeBeds >= NUMBER_OF_BIG_LIVINGHOUSE_BEDS + 1
+				&& aiStatistics.getNumberOfBuildingTypeForPlayer(EBuildingType.BIG_LIVINGHOUSE, playerId) > 0) {
 			taskScheduler.scheduleTask(new DestroyBuildingGuiTask(playerId,
 					aiStatistics.getBuildingPositionsOfTypeForPlayer(EBuildingType.BIG_LIVINGHOUSE, playerId).get(0)));
 		}
 
 		// destroy mines
-		for (ShortPoint2D mine: aiStatistics.getDeadMinesOf(playerId)) {
+		for (ShortPoint2D mine : aiStatistics.getDeadMinesOf(playerId)) {
 			taskScheduler.scheduleTask(new DestroyBuildingGuiTask(playerId, mine));
 		}
 	}
@@ -314,8 +314,8 @@ public class WhatToDoAi implements IWhatToDoAi {
 
 		int futureNumberOfBearers = aiStatistics.getMovablePositionsByTypeForPlayer(EMovableType.BEARER, playerId).size()
 				+ aiStatistics.getNumberOfNotFinishedBuildingTypesForPlayer(BIG_LIVINGHOUSE, playerId) * NUMBER_OF_BIG_LIVINGHOUSE_BEDS;
-		if (futureNumberOfBearers < MINIMUM_NUMBER_OF_BEARERS || aiStatistics.getNumberOfTotalBuildingsForPlayer(playerId) * NUMBER_OF_BEARERSS_PER_HOUSE
-				> futureNumberOfBearers) {
+		if (futureNumberOfBearers < MINIMUM_NUMBER_OF_BEARERS
+				|| aiStatistics.getNumberOfTotalBuildingsForPlayer(playerId) * NUMBER_OF_BEARERSS_PER_HOUSE > futureNumberOfBearers) {
 			if (aiStatistics.getTotalNumberOfBuildingTypeForPlayer(STONECUTTER, playerId) < 1
 					|| aiStatistics.getTotalNumberOfBuildingTypeForPlayer(LUMBERJACK, playerId) < 3) {
 				return construct(SMALL_LIVINGHOUSE);

--- a/jsettlers.logic/src/jsettlers/ai/highlevel/WhatToDoAiFactory.java
+++ b/jsettlers.logic/src/jsettlers/ai/highlevel/WhatToDoAiFactory.java
@@ -20,7 +20,7 @@ import jsettlers.ai.army.WinnerGeneral;
 import jsettlers.ai.economy.EconomyMinister;
 import jsettlers.ai.economy.LooserEconomyMinister;
 import jsettlers.ai.economy.WinnerEconomyMinister;
-import jsettlers.common.ai.WhatToDoAiType;
+import jsettlers.common.ai.EWhatToDoAiType;
 import jsettlers.logic.map.grid.MainGrid;
 import jsettlers.logic.map.grid.movable.MovableGrid;
 import jsettlers.logic.player.Player;
@@ -31,7 +31,7 @@ import jsettlers.network.client.interfaces.ITaskScheduler;
  */
 public class WhatToDoAiFactory {
 
-	public IWhatToDoAi buildWhatToDoAi(WhatToDoAiType type, AiStatistics aiStatistics, Player player, MainGrid mainGrid, MovableGrid movableGrid,
+	public IWhatToDoAi buildWhatToDoAi(EWhatToDoAiType type, AiStatistics aiStatistics, Player player, MainGrid mainGrid, MovableGrid movableGrid,
 			ITaskScheduler
 			taskScheduler) {
 		ArmyGeneral general = determineArmyGeneral(type, aiStatistics, player, movableGrid, taskScheduler);
@@ -39,15 +39,15 @@ public class WhatToDoAiFactory {
 		return new WhatToDoAi(player.playerId, aiStatistics, minister, general, mainGrid, taskScheduler);
 	}
 
-	private EconomyMinister determineMinister(WhatToDoAiType type) {
-		if (type == WhatToDoAiType.ROMAN_EASY || type == WhatToDoAiType.ROMAN_VERY_HARD) {
+	private EconomyMinister determineMinister(EWhatToDoAiType type) {
+		if (type == EWhatToDoAiType.ROMAN_EASY || type == EWhatToDoAiType.ROMAN_VERY_HARD) {
 			return new WinnerEconomyMinister();
 		}
 		return new LooserEconomyMinister();
 	}
 
-	private ArmyGeneral determineArmyGeneral(WhatToDoAiType type, AiStatistics aiStatistics, Player player, MovableGrid movableGrid, ITaskScheduler taskScheduler) {
-		if (type == WhatToDoAiType.ROMAN_HARD || type == WhatToDoAiType.ROMAN_VERY_HARD) {
+	private ArmyGeneral determineArmyGeneral(EWhatToDoAiType type, AiStatistics aiStatistics, Player player, MovableGrid movableGrid, ITaskScheduler taskScheduler) {
+		if (type == EWhatToDoAiType.ROMAN_HARD || type == EWhatToDoAiType.ROMAN_VERY_HARD) {
 			return new WinnerGeneral(aiStatistics, player, movableGrid, taskScheduler);
 		}
 		return new LooserGeneral(aiStatistics, player, movableGrid, taskScheduler);

--- a/jsettlers.logic/src/jsettlers/logic/map/grid/MainGrid.java
+++ b/jsettlers.logic/src/jsettlers/logic/map/grid/MainGrid.java
@@ -303,7 +303,16 @@ public final class MainGrid implements Serializable {
 
 		short[] bgImage = previewImageCreator.getPreviewImage();
 
-		return new MapFileHeader(MapType.SAVED_SINGLE, mapName, mapId, "TODO: description", width, height, (short) 1, (short) 1, new Date(), bgImage);
+		return new MapFileHeader(
+				MapType.SAVED_SINGLE,
+				mapName, mapId,
+				"TODO: description",
+				width,
+				height,
+				(short) 1,
+				getPartitionsGrid().getNumberOfPlayers(),
+				new Date(),
+				bgImage);
 	}
 
 	private void placeStack(ShortPoint2D pos, EMaterialType materialType, int count) {

--- a/jsettlers.logic/src/jsettlers/logic/map/save/loader/MapLoader.java
+++ b/jsettlers.logic/src/jsettlers/logic/map/save/loader/MapLoader.java
@@ -180,7 +180,7 @@ public abstract class MapLoader implements IGameCreator, Comparable<MapLoader>, 
 		if (playerSettings == null || CommonConstants.ACTIVATE_ALL_PLAYERS) {
 			playerSettings = new PlayerSetting[numberOfPlayers];
 			for (int i = 0; i < numberOfPlayers; i++) {
-				playerSettings[i] = new PlayerSetting(true, false);
+				playerSettings[i] = new PlayerSetting(true, false, null);
 			}
 		}
 

--- a/jsettlers.logic/src/jsettlers/logic/map/save/loader/MapLoader.java
+++ b/jsettlers.logic/src/jsettlers/logic/map/save/loader/MapLoader.java
@@ -180,7 +180,7 @@ public abstract class MapLoader implements IGameCreator, Comparable<MapLoader>, 
 		if (playerSettings == null || CommonConstants.ACTIVATE_ALL_PLAYERS) {
 			playerSettings = new PlayerSetting[numberOfPlayers];
 			for (int i = 0; i < numberOfPlayers; i++) {
-				playerSettings[i] = new PlayerSetting(true, false, null);
+				playerSettings[i] = new PlayerSetting(true);
 			}
 		}
 

--- a/jsettlers.logic/src/jsettlers/logic/player/PlayerSetting.java
+++ b/jsettlers.logic/src/jsettlers/logic/player/PlayerSetting.java
@@ -1,17 +1,25 @@
 package jsettlers.logic.player;
 
+import jsettlers.common.ai.WhatToDoAiType;
+
 /**
  * @author codingberlin
  */
 public class PlayerSetting {
 
-	boolean isAvailable;
-	boolean isAi;
+	final boolean isAi;
 
-	public PlayerSetting(boolean isAvailable, boolean isAi) {
+	final WhatToDoAiType aiType;
+
+	boolean isAvailable;
+
+	public PlayerSetting(boolean isAvailable, boolean isAi, WhatToDoAiType aiType) {
+		if (isAi && aiType == null) {
+			throw new IllegalArgumentException("isAi = true specified but aiType is null.");
+		}
 		this.isAvailable = isAvailable;
 		this.isAi = isAi;
-
+		this.aiType = aiType;
 	}
 
 	public boolean isAvailable() {
@@ -22,8 +30,12 @@ public class PlayerSetting {
 		return isAi;
 	}
 
+	public WhatToDoAiType getAiType() {
+		return aiType;
+	}
+
 	@Override
 	public String toString() {
-		return "PlayerSetting(isAvailable: " + isAvailable + ", isAi: " + isAi + ")";
+		return "PlayerSetting(isAvailable: " + isAvailable + ", isAi: " + isAi + ", aiType)" + aiType;
 	}
 }

--- a/jsettlers.logic/src/jsettlers/logic/player/PlayerSetting.java
+++ b/jsettlers.logic/src/jsettlers/logic/player/PlayerSetting.java
@@ -1,24 +1,35 @@
 package jsettlers.logic.player;
 
-import jsettlers.common.ai.WhatToDoAiType;
+import jsettlers.common.ai.EWhatToDoAiType;
 
 /**
  * @author codingberlin
  */
 public class PlayerSetting {
 
-	final boolean isAi;
+	private final boolean isAi;
+	private final EWhatToDoAiType aiType;
+	private boolean isAvailable;
 
-	final WhatToDoAiType aiType;
+	/**
+	 * Creates a new {@link PlayerSetting} object for a human player.
+	 * 
+	 * @param isAvailable
+	 */
+	public PlayerSetting(boolean isAvailable) {
+		this(isAvailable, null);
+	}
 
-	boolean isAvailable;
-
-	public PlayerSetting(boolean isAvailable, boolean isAi, WhatToDoAiType aiType) {
-		if (isAi && aiType == null) {
-			throw new IllegalArgumentException("isAi = true specified but aiType is null.");
-		}
+	/**
+	 * Creates a new {@link PlayerSetting} object for a human player or an AI player.
+	 * 
+	 * @param isAvailable
+	 * @param aiType
+	 *            {@link EWhatToDoAiType} defining the type of the AI player. If <code>null</code>, a human player is assumed.
+	 */
+	public PlayerSetting(boolean isAvailable, EWhatToDoAiType aiType) {
 		this.isAvailable = isAvailable;
-		this.isAi = isAi;
+		this.isAi = (aiType != null);
 		this.aiType = aiType;
 	}
 
@@ -30,12 +41,12 @@ public class PlayerSetting {
 		return isAi;
 	}
 
-	public WhatToDoAiType getAiType() {
+	public EWhatToDoAiType getAiType() {
 		return aiType;
 	}
 
 	@Override
 	public String toString() {
-		return "PlayerSetting(isAvailable: " + isAvailable + ", isAi: " + isAi + ", aiType)" + aiType;
+		return "PlayerSetting(isAvailable: " + isAvailable + ", isAi: " + isAi + ", aiType: " + aiType + ")";
 	}
 }

--- a/jsettlers.logic/src/jsettlers/main/MultiplayerGame.java
+++ b/jsettlers.logic/src/jsettlers/main/MultiplayerGame.java
@@ -18,7 +18,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import jsettlers.common.CommonConstants;
-import jsettlers.common.ai.WhatToDoAiType;
+import jsettlers.common.ai.EWhatToDoAiType;
 import jsettlers.common.utils.collections.ChangingList;
 import jsettlers.graphics.startscreen.interfaces.ENetworkMessage;
 import jsettlers.graphics.startscreen.interfaces.IChatMessageListener;
@@ -145,11 +145,11 @@ public class MultiplayerGame {
 		PlayerSetting[] playerSettings = new PlayerSetting[availablePlayers.length];
 
 		for (byte i = 0; i < playersList.getItems().size(); i++) {
-			playerSettings[i] = new PlayerSetting(true, false, null);
+			playerSettings[i] = new PlayerSetting(true);
 		}
 
 		for (byte i = (byte) playersList.getItems().size(); i < availablePlayers.length; i++) {
-			playerSettings[i] = new PlayerSetting(true, CommonConstants.ENABLE_AI && aiPlayersEnabled, WhatToDoAiType.getTypeByIndex(i));
+			playerSettings[i] = new PlayerSetting(CommonConstants.ENABLE_AI && aiPlayersEnabled, EWhatToDoAiType.getTypeByIndex(i));
 		}
 
 		return playerSettings;

--- a/jsettlers.logic/src/jsettlers/main/MultiplayerGame.java
+++ b/jsettlers.logic/src/jsettlers/main/MultiplayerGame.java
@@ -17,6 +17,8 @@ package jsettlers.main;
 import java.util.LinkedList;
 import java.util.List;
 
+import jsettlers.common.CommonConstants;
+import jsettlers.common.ai.WhatToDoAiType;
 import jsettlers.common.utils.collections.ChangingList;
 import jsettlers.graphics.startscreen.interfaces.ENetworkMessage;
 import jsettlers.graphics.startscreen.interfaces.IChatMessageListener;
@@ -143,11 +145,11 @@ public class MultiplayerGame {
 		PlayerSetting[] playerSettings = new PlayerSetting[availablePlayers.length];
 
 		for (byte i = 0; i < playersList.getItems().size(); i++) {
-			playerSettings[i] = new PlayerSetting(true, false);
+			playerSettings[i] = new PlayerSetting(true, false, null);
 		}
 
 		for (byte i = (byte) playersList.getItems().size(); i < availablePlayers.length; i++) {
-			playerSettings[i] = new PlayerSetting(true, aiPlayersEnabled);
+			playerSettings[i] = new PlayerSetting(true, CommonConstants.ENABLE_AI && aiPlayersEnabled, WhatToDoAiType.getTypeByIndex(i));
 		}
 
 		return playerSettings;

--- a/jsettlers.logic/src/jsettlers/main/ReplayStartInformation.java
+++ b/jsettlers.logic/src/jsettlers/main/ReplayStartInformation.java
@@ -69,7 +69,7 @@ public class ReplayStartInformation {
 	public PlayerSetting[] getPlayerSettings() {
 		PlayerSetting[] playerSettings = new PlayerSetting[availablePlayers.length];
 		for (int i = 0; i < availablePlayers.length; i++) {
-			playerSettings[i] = new PlayerSetting(availablePlayers[i], false);
+			playerSettings[i] = new PlayerSetting(availablePlayers[i], false, null);
 		}
 		return playerSettings;
 	}

--- a/jsettlers.logic/src/jsettlers/main/ReplayStartInformation.java
+++ b/jsettlers.logic/src/jsettlers/main/ReplayStartInformation.java
@@ -14,11 +14,11 @@
  *******************************************************************************/
 package jsettlers.main;
 
-import jsettlers.logic.player.PlayerSetting;
-
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+
+import jsettlers.logic.player.PlayerSetting;
 
 /**
  * 
@@ -41,7 +41,6 @@ public class ReplayStartInformation {
 		this.playerId = playerId;
 		this.mapName = mapName;
 		this.mapId = mapId;
-
 
 		boolean[] availablePlayers = new boolean[playerSettings.length];
 		for (int i = 0; i < playerSettings.length; i++) {
@@ -69,7 +68,7 @@ public class ReplayStartInformation {
 	public PlayerSetting[] getPlayerSettings() {
 		PlayerSetting[] playerSettings = new PlayerSetting[availablePlayers.length];
 		for (int i = 0; i < availablePlayers.length; i++) {
-			playerSettings[i] = new PlayerSetting(availablePlayers[i], false, null);
+			playerSettings[i] = new PlayerSetting(availablePlayers[i]);
 		}
 		return playerSettings;
 	}

--- a/jsettlers.logic/src/jsettlers/main/StartScreenConnector.java
+++ b/jsettlers.logic/src/jsettlers/main/StartScreenConnector.java
@@ -15,6 +15,7 @@
 package jsettlers.main;
 
 import jsettlers.common.CommonConstants;
+import jsettlers.common.ai.WhatToDoAiType;
 import jsettlers.common.utils.collections.ChangingList;
 import jsettlers.graphics.startscreen.interfaces.IMapDefinition;
 import jsettlers.graphics.startscreen.interfaces.IMultiplayerConnector;
@@ -74,9 +75,9 @@ public class StartScreenConnector implements IStartScreen {
 		long randomSeed = 4711L;
 		byte playerId = 0;
 		PlayerSetting[] playerSettings = new PlayerSetting[mapLoader.getMaxPlayers()];
-		playerSettings[playerId] = new PlayerSetting(true, false);
+		playerSettings[playerId] = new PlayerSetting(true, false, null);
 		for (byte i = 0; i < playerSettings.length; i++) {
-			playerSettings[i] = new PlayerSetting(true, CommonConstants.ENABLE_AI && i != playerId);
+			playerSettings[i] = new PlayerSetting(true, CommonConstants.ENABLE_AI && i != playerId, WhatToDoAiType.getTypeByIndex(i));
 		}
 
 		JSettlersGame game = new JSettlersGame(mapLoader, randomSeed, playerId, playerSettings);

--- a/jsettlers.logic/src/jsettlers/main/StartScreenConnector.java
+++ b/jsettlers.logic/src/jsettlers/main/StartScreenConnector.java
@@ -15,7 +15,7 @@
 package jsettlers.main;
 
 import jsettlers.common.CommonConstants;
-import jsettlers.common.ai.WhatToDoAiType;
+import jsettlers.common.ai.EWhatToDoAiType;
 import jsettlers.common.utils.collections.ChangingList;
 import jsettlers.graphics.startscreen.interfaces.IMapDefinition;
 import jsettlers.graphics.startscreen.interfaces.IMultiplayerConnector;
@@ -75,9 +75,11 @@ public class StartScreenConnector implements IStartScreen {
 		long randomSeed = 4711L;
 		byte playerId = 0;
 		PlayerSetting[] playerSettings = new PlayerSetting[mapLoader.getMaxPlayers()];
-		playerSettings[playerId] = new PlayerSetting(true, false, null);
+		playerSettings[playerId] = new PlayerSetting(true);
 		for (byte i = 0; i < playerSettings.length; i++) {
-			playerSettings[i] = new PlayerSetting(true, CommonConstants.ENABLE_AI && i != playerId, WhatToDoAiType.getTypeByIndex(i));
+			if (i != playerId) {
+				playerSettings[i] = new PlayerSetting(CommonConstants.ENABLE_AI, EWhatToDoAiType.getTypeByIndex(i));
+			}
 		}
 
 		JSettlersGame game = new JSettlersGame(mapLoader, randomSeed, playerId, playerSettings);

--- a/jsettlers.main.swing/src/jsettlers/main/swing/SwingManagedJSettlers.java
+++ b/jsettlers.main.swing/src/jsettlers/main/swing/SwingManagedJSettlers.java
@@ -33,6 +33,7 @@ import go.graphics.swing.AreaContainer;
 import go.graphics.swing.sound.SwingSoundPlayer;
 import jsettlers.common.CommitInfo;
 import jsettlers.common.CommonConstants;
+import jsettlers.common.ai.WhatToDoAiType;
 import jsettlers.common.map.MapLoadException;
 import jsettlers.common.resources.ResourceManager;
 import jsettlers.common.utils.MainUtils;
@@ -232,10 +233,10 @@ public class SwingManagedJSettlers {
 				MapLoader mapLoader = MapLoader.getLoaderForListedMap(new DirectoryMapLister.ListedMapFile(new File(mapfile)));
 				byte playerId = 0;
 				PlayerSetting[] playerSettings = new PlayerSetting[mapLoader.getMaxPlayers()];
-				playerSettings[playerId] = new PlayerSetting(true, false);
+				playerSettings[playerId] = new PlayerSetting(true, false, null);
 				for (byte i = 0; i < playerSettings.length; i++) {
 					if (i != playerId) {
-						playerSettings[i] = new PlayerSetting(false, true);
+						playerSettings[i] = new PlayerSetting(false, CommonConstants.ENABLE_AI && true, WhatToDoAiType.getTypeByIndex(i));
 					}
 				}
 

--- a/jsettlers.main.swing/src/jsettlers/main/swing/SwingManagedJSettlers.java
+++ b/jsettlers.main.swing/src/jsettlers/main/swing/SwingManagedJSettlers.java
@@ -33,7 +33,7 @@ import go.graphics.swing.AreaContainer;
 import go.graphics.swing.sound.SwingSoundPlayer;
 import jsettlers.common.CommitInfo;
 import jsettlers.common.CommonConstants;
-import jsettlers.common.ai.WhatToDoAiType;
+import jsettlers.common.ai.EWhatToDoAiType;
 import jsettlers.common.map.MapLoadException;
 import jsettlers.common.resources.ResourceManager;
 import jsettlers.common.utils.MainUtils;
@@ -233,10 +233,10 @@ public class SwingManagedJSettlers {
 				MapLoader mapLoader = MapLoader.getLoaderForListedMap(new DirectoryMapLister.ListedMapFile(new File(mapfile)));
 				byte playerId = 0;
 				PlayerSetting[] playerSettings = new PlayerSetting[mapLoader.getMaxPlayers()];
-				playerSettings[playerId] = new PlayerSetting(true, false, null);
+				playerSettings[playerId] = new PlayerSetting(true);
 				for (byte i = 0; i < playerSettings.length; i++) {
 					if (i != playerId) {
-						playerSettings[i] = new PlayerSetting(false, CommonConstants.ENABLE_AI && true, WhatToDoAiType.getTypeByIndex(i));
+						playerSettings[i] = new PlayerSetting(CommonConstants.ENABLE_AI && true, EWhatToDoAiType.getTypeByIndex(i));
 					}
 				}
 


### PR DESCRIPTION
To support issue #140 I introduce computer difficulties so that @adamjryan can make the following computer difficulties choosable by multiplayer join screen/singleplayer selection screen:

- **Very Easy** *LooserEconomyMinister & LooserGeneral*
- **Easy** *WinnerEconomyMinister & LooserGeneral*
- **Hard** *LooserEconomyMinister & WinnerGeneral*
- **Very Hard** *WinnerEconomyMinister & WinnerGeneral*

**WinnerEconomyMinister** is the high optimized computer player as you know it
**LooserEconomyMinister** builds less building material economy, less mana, late towers, inefficient weapons industry and causes sometimes lack of soldiers
**WinnerGeneral** is not finished yet because of missing features in the game. (Stop to recruit, store weapons, determine which weapons should be produced) (I add the WinnerGeneral in this early state to point to the idea to have different generals)
**LooserGeneral** produces inefficient mix of different troops, does not wait for level3, attacks only with the same number of soldiers as the enemy target has, so that a loose is very probable, because of the combat strength.

To use all 4 difficulties for a start the difficulty is chosen by round robin and depends on the playerId. Of course this will be removed, when the difficulty can be chosen by the UI later.