### PR TITLE
make shadow darker

### DIFF
--- a/jsettlers.graphics/src/jsettlers/graphics/map/draw/Background.java
+++ b/jsettlers.graphics/src/jsettlers/graphics/map/draw/Background.java
@@ -1727,7 +1727,7 @@ public class Background implements IGraphicsBackgroundListener {
 		} else {
 			int height1 = context.getHeight(x, y - 1);
 			int height2 = context.getHeight(x, y);
-			float fcolor = 0.9f + (height1 - height2) * .1f;
+			float fcolor = 0.85f + (height1 - height2) * .15f;
 			if (fcolor > 1.0f) {
 				fcolor = 1.0f;
 			} else if (fcolor < 0.4f) {


### PR DESCRIPTION
This PR is to make the landscape more plastic by making the shadow darker.

The landscape before the PR:
<img width="1041" alt="bildschirmfoto 2015-11-14 um 09 30 47" src="https://cloud.githubusercontent.com/assets/6422616/11162823/012131dc-8ab3-11e5-9d24-e5afe03a6b90.png">

The landscape in the original game:
![original](https://cloud.githubusercontent.com/assets/6422616/11113738/964b1204-891f-11e5-9821-3f2bcfbeaf39.png)

The landscape after the PR:
<img width="1145" alt="bildschirmfoto 2015-11-14 um 09 32 05" src="https://cloud.githubusercontent.com/assets/6422616/11162825/159b1a10-8ab3-11e5-9d3a-d0144a3c69b6.png">

With this PR the landscapes become more closer to the original but as you can see in the screenshot from the original game there the hills are not only dark but lighten as well.
I was not able to find out how to lighten the textures. even by setting the colors to 255 255 255 didn't lighten them, this just let the original landscape color as it is.