### PR TITLE
Change using of JFileChooser() to FileDialog() cause issue #240

### DIFF
--- a/jsettlers.graphics.swing/src/jsettlers/graphics/swing/resources/ConfigurationPropertiesFile.java
+++ b/jsettlers.graphics.swing/src/jsettlers/graphics/swing/resources/ConfigurationPropertiesFile.java
@@ -35,7 +35,7 @@ public class ConfigurationPropertiesFile {
 
 	public ConfigurationPropertiesFile(File file) throws FileNotFoundException,
 			IOException {
-		this.configFile = file;
+		this.configFile = file.getAbsoluteFile();
 
 		Properties defaultProperties = new Properties();
 		defaultProperties.load(ConfigurationPropertiesFile.class.getResourceAsStream("defaultConfig.prp"));
@@ -51,8 +51,7 @@ public class ConfigurationPropertiesFile {
 		File dir = new File(property);
 		if (!dir.isAbsolute()) {
 			String parent = configFile.getParent();
-			dir = new File((parent == null ? "" : parent + File.separator)
-					+ property);
+			dir = new File((((parent == null) ? "" : parent) + File.separator) + property);
 		}
 		return dir.getAbsoluteFile();
 	}
@@ -66,9 +65,14 @@ public class ConfigurationPropertiesFile {
 		String[] result = new String[settlersFolder.length * subfolders.length];
 
 		int resultIdx = 0;
-		for (int subfolderIdx = 0; subfolderIdx < subfolders.length; subfolderIdx++) {
-			for (int folderIdx = 0; folderIdx < settlersFolder.length; folderIdx++) {
-				result[resultIdx++] = settlersFolder[folderIdx].replaceFirst("/?$", "/" + subfolders[subfolderIdx]);
+		for (int folderIdx = 0; folderIdx < settlersFolder.length; folderIdx++) {
+			
+			//- check if path ends with File-separator. If not -> Add!
+			String path = settlersFolder[folderIdx];
+			if (path.substring(path.length()-1) != File.separator) path += File.separator;
+			
+			for (int subfolderIdx = 0; subfolderIdx < subfolders.length; subfolderIdx++) {
+				result[resultIdx++] = path + subfolders[subfolderIdx];
 			}
 		}
 		return result;

--- a/jsettlers.graphics.swing/src/jsettlers/graphics/swing/resources/SwingResourceProvider.java
+++ b/jsettlers.graphics.swing/src/jsettlers/graphics/swing/resources/SwingResourceProvider.java
@@ -27,7 +27,7 @@ public class SwingResourceProvider implements IResourceProvider {
 	private final String resourcesFolder;
 
 	public SwingResourceProvider(File file) {
-		this.resourcesFolder = file.getPath() + file.separator;
+		this.resourcesFolder = file.getPath() + File.separator;
 	}
 
 	@Override

--- a/jsettlers.graphics.swing/src/jsettlers/graphics/swing/resources/SwingResourceProvider.java
+++ b/jsettlers.graphics.swing/src/jsettlers/graphics/swing/resources/SwingResourceProvider.java
@@ -27,7 +27,7 @@ public class SwingResourceProvider implements IResourceProvider {
 	private final String resourcesFolder;
 
 	public SwingResourceProvider(File file) {
-		this.resourcesFolder = file.getPath() + "/";
+		this.resourcesFolder = file.getPath() + file.separator;
 	}
 
 	@Override

--- a/jsettlers.main.swing/config.prp
+++ b/jsettlers.main.swing/config.prp
@@ -1,7 +1,4 @@
-#This properties are used for development
-
-#Specifies the folder where the resources can be found. NOTE: The path needs to end with a slash ( / )
+#Updated settlers-folder with dialog.
+#Sun Nov 22 21:25:55 CET 2015
 resources-folder=../jsettlers.common/resources/
 
-#Folder containing the folders of the graphics and the sound files. If you want to specify multiple possible folders, use a ";" character for separation.
-settlers-folder=/home/michael/.jsettlers;D:/Games/Siedler3;C:/Program Files/siedler 3

--- a/jsettlers.main.swing/src/jsettlers/main/swing/SwingManagedJSettlers.java
+++ b/jsettlers.main.swing/src/jsettlers/main/swing/SwingManagedJSettlers.java
@@ -15,6 +15,7 @@
 package jsettlers.main.swing;
 
 import java.awt.Dimension;
+import java.awt.FileDialog;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -27,6 +28,7 @@ import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 import javax.swing.filechooser.FileFilter;
+import javax.swing.*;
 
 import go.graphics.area.Area;
 import go.graphics.swing.AreaContainer;
@@ -79,6 +81,44 @@ public class SwingManagedJSettlers {
 		generateContent(argsMap, content);
 	}
 
+	private static String getSelectedFolderName() {
+		
+		//- Info: Don't use JFileChooser(), some Windows User have problems caused by a NullPointerException in FileDialog()
+		//-   see issue #240: https://github.com/jsettlers/settlers-remake/issues/240
+		
+		
+		//- see: http://stackoverflow.com/questions/1224714/how-can-i-make-a-java-filedialog-accept-directories-as-its-filetype-in-os-x
+		JFrame frame = new JFrame();
+		
+		System.setProperty("apple.awt.fileDialogForDirectories", "true");
+		FileDialog fd = new FileDialog(frame, Labels.getString("select-settlers-3-folder"), FileDialog.LOAD); 
+		fd.setVisible(true); 
+		String selectedFolderName = fd.getDirectory();
+		System.setProperty("apple.awt.fileDialogForDirectories", "false");
+		
+		//- user clicked cancel button
+		if (selectedFolderName == null) return null;
+		
+		//- try to check if the selection is really a Folder  
+		try {
+			File file = new File(selectedFolderName);
+			if (!file.isDirectory()) {
+				 return null;
+			}
+			
+			if (file.exists()){
+				//- OK looks good
+				return selectedFolderName;
+			}
+		}
+		catch (Exception e) {
+			return null;
+		}
+		
+		return null;
+	}
+	
+	
 	/**
 	 * Sets up the {@link ResourceManager} by using a configuration file. <br>
 	 * First it is checked, if the given argsMap contains a "configFile" parameter. If so, the path specified for this parameter is used to get the
@@ -102,36 +142,21 @@ public class SwingManagedJSettlers {
 				JOptionPane.showMessageDialog(null, Labels.getString("settlers-folder-still-invalid"));
 			}
 			firstRun = false;
-
-			JFileChooser fileDialog = new JFileChooser();
-			fileDialog.setAcceptAllFileFilterUsed(false);
-			fileDialog.setFileFilter(new FileFilter() {
-				@Override
-				public String getDescription() {
-					return null;
-				}
-
-				@Override
-				public boolean accept(File f) {
-					return f.isDirectory();
-				}
-			});
-			fileDialog.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
-			fileDialog.setDialogType(JFileChooser.SAVE_DIALOG);
-			fileDialog.setMultiSelectionEnabled(false);
-			fileDialog.setDialogTitle(Labels.getString("select-settlers-3-folder"));
-			fileDialog.showOpenDialog(null);
-
-			File selectedFolder = fileDialog.getSelectedFile();
-			if (selectedFolder == null) {
+			
+			String selectedFolderName = getSelectedFolderName();
+	        
+			if (selectedFolderName == null) {
 				String noFolderSelctedMessage = Labels.getString("error-no-settlers-3-folder-selected");
 				JOptionPane.showMessageDialog(null, noFolderSelctedMessage);
 				System.err.println(noFolderSelctedMessage);
 				System.exit(1);
 			}
 
-			System.out.println(selectedFolder);
+			System.out.println(selectedFolderName);
+			
 			try {
+				File selectedFolder = new File(selectedFolderName);
+				
 				configFile.setSettlersFolder(selectedFolder);
 			} catch (IOException ex) {
 				String errorSavingSettingsMessage = Labels.getString("error-settings-not-saveable");


### PR DESCRIPTION
- Change using of JFileChooser() to FileDialog() cause issue #240
- Known bugs: the nativ FileDialog() only can select a File not a Folder (the nativ DirectoryDialog would require the  import of org.eclipse.swt.*)
- some "/" to "File.Separator" fixes