### PR TITLE
Fix saving error by making private class serializable.

### DIFF
--- a/jsettlers.logic/src/jsettlers/logic/buildings/trading/MarketBuilding.java
+++ b/jsettlers.logic/src/jsettlers/logic/buildings/trading/MarketBuilding.java
@@ -16,6 +16,7 @@ package jsettlers.logic.buildings.trading;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -97,7 +98,8 @@ public class MarketBuilding extends TradingBuilding implements IDonkeyMarket {
 		return new WaypointsIterator(getWaypoints());
 	}
 
-	private static class WaypointsIterator implements Iterator<ShortPoint2D> {
+	private static class WaypointsIterator implements Iterator<ShortPoint2D>, Serializable {
+		private static final long serialVersionUID = 5229610228646171358L;
 
 		private final ShortPoint2D[] waypoints;
 		private int i = 0;


### PR DESCRIPTION
Private class `MarketBuilding$WaypointIterator` needs to be serializable, as it seems. With this modification, I can save games even if I got active markets.