### PR TITLE
Moved DoubleLinkedIntListItem to commons project

### DIFF
--- a/jsettlers.common/src/main/java/jsettlers/common/utils/collections/list/DoubleLinkedIntListItem.java
+++ b/jsettlers.common/src/main/java/jsettlers/common/utils/collections/list/DoubleLinkedIntListItem.java
@@ -12,9 +12,7 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  *******************************************************************************/
-package jsettlers.algorithms.path.astar.queues.bucket;
-
-import jsettlers.common.utils.collections.list.DoubleLinkedListItem;
+package jsettlers.common.utils.collections.list;
 
 /**
  * This class represents a single item of a {@link DoubleLinkedIntList}.

--- a/jsettlers.common/src/test/java/jsettlers/common/buildings/BuildingConfigurationsTest.java
+++ b/jsettlers.common/src/test/java/jsettlers/common/buildings/BuildingConfigurationsTest.java
@@ -13,7 +13,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-import jsettlers.testutils.TestUtils;
 import jsettlers.common.buildings.stacks.RelativeStack;
 import jsettlers.common.position.RelativePoint;
 

--- a/jsettlers.common/src/test/java/jsettlers/common/utils/collections/list/DoubleLinkedListTest.java
+++ b/jsettlers.common/src/test/java/jsettlers/common/utils/collections/list/DoubleLinkedListTest.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.util.Iterator;
 
 import jsettlers.testutils.TestUtils;
-import jsettlers.algorithms.path.astar.queues.bucket.DoubleLinkedIntListItem;
 
 import org.junit.Test;
 

--- a/jsettlers.logic/src/main/java/jsettlers/algorithms/path/astar/queues/bucket/ListMinBucketQueue.java
+++ b/jsettlers.logic/src/main/java/jsettlers/algorithms/path/astar/queues/bucket/ListMinBucketQueue.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package jsettlers.algorithms.path.astar.queues.bucket;
 
+import jsettlers.common.utils.collections.list.DoubleLinkedIntListItem;
 import jsettlers.common.utils.collections.list.DoubleLinkedList;
 
 /**


### PR DESCRIPTION
The class is also used in the jsettlers.common tests and can be used by other classes too. 