### PR TITLE
fix typo in original maps folder name

### DIFF
--- a/jsettlers.main.swing/src/main/java/jsettlers/main/swing/resources/SettlersFolderChecker.java
+++ b/jsettlers.main.swing/src/main/java/jsettlers/main/swing/resources/SettlersFolderChecker.java
@@ -74,7 +74,7 @@ public final class SettlersFolderChecker {
 						gfxFolder = f;
 					}
 				}
-			} else if(f.getName().equalsIgnoreCase("maps")) {
+			} else if(f.getName().equalsIgnoreCase("map")) {
 				mapsFolder = f;
 			}
 		}


### PR DESCRIPTION
While "Refactored swing resource setup process and map loading." a wrong additional "s" sneaked into the original map folder name:

https://github.com/jsettlers/settlers-remake/commit/0f75f6cc62e8d7659bbd8ae8debfa65ad7bae7ab#diff-7669e7db194af25e7d0f23bd803e412bL85

https://github.com/jsettlers/settlers-remake/commit/0f75f6cc62e8d7659bbd8ae8debfa65ad7bae7ab#diff-92c3c4876e04106451fce9fb370a5f55R77

This removes it, so that you can load original maps again.