### PR TITLE
Removed CONTROL_ALL option as standard for single player games.

### DIFF
--- a/jsettlers.common/src/main/java/jsettlers/common/CommonConstants.java
+++ b/jsettlers.common/src/main/java/jsettlers/common/CommonConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015
+ * Copyright (c) 2015, 2016
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
@@ -49,13 +49,6 @@ public abstract class CommonConstants {
 	 * Makes the graphics print timing information to the console.
 	 */
 	public static final boolean ENABLE_GRAPHICS_TIMES_DEBUG_OUTPUT = false;
-
-	/**
-	 * NOTE: this value has only an effect if it's changed before the MainGrid is created! IT MUSTN'T BE CHANGED AFTER A MAIN GRID HAS BEEN CREATED <br>
-	 * if false, no debug coloring is possible (but saves memory) <br>
-	 * if true, debug coloring is possible.
-	 */
-	public static boolean ENABLE_DEBUG_COLORS = true;
 
 	/**
 	 * This is the default address the network game connects to.

--- a/jsettlers.logic/src/main/java/jsettlers/logic/constants/MatchConstants.java
+++ b/jsettlers.logic/src/main/java/jsettlers/logic/constants/MatchConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015
+ * Copyright (c) 2015, 2016
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
@@ -37,6 +37,13 @@ public final class MatchConstants {
 	public static boolean ENABLE_ALL_PLAYER_SELECTION = false;
 
 	public static boolean ENABLE_FOG_OF_WAR_DISABLING = false;
+
+	/**
+	 * NOTE: this value has only an effect if it's changed before the MainGrid is created! IT MUSTN'T BE CHANGED AFTER A MAIN GRID HAS BEEN CREATED <br>
+	 * if false, no debug coloring is possible (but saves memory) <br>
+	 * if true, debug coloring is possible.
+	 */
+	public static boolean ENABLE_DEBUG_COLORS = true;
 
 	private MatchConstants() {
 	}

--- a/jsettlers.logic/src/main/java/jsettlers/logic/map/grid/MainGrid.java
+++ b/jsettlers.logic/src/main/java/jsettlers/logic/map/grid/MainGrid.java
@@ -716,6 +716,10 @@ public final class MainGrid implements Serializable {
 
 		@Override
 		public final int getDebugColorAt(int x, int y, EDebugColorModes debugColorMode) {
+			if (!MatchConstants.ENABLE_DEBUG_COLORS) {
+				return 0;
+			}
+
 			switch (debugColorMode) {
 			case BLOCKED_PARTITIONS:
 				return getScaledColor(landscapeGrid.getBlockedPartitionAt(x, y) + 1);
@@ -740,7 +744,7 @@ public final class MainGrid implements Serializable {
 				return Color.getARGB(1, .6f, 0, resource);
 			case NONE:
 			default:
-				return -1;
+				return 0;
 			}
 		}
 

--- a/jsettlers.logic/src/main/java/jsettlers/logic/map/grid/landscape/LandscapeGrid.java
+++ b/jsettlers.logic/src/main/java/jsettlers/logic/map/grid/landscape/LandscapeGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015
+ * Copyright (c) 2015, 2016
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
@@ -19,7 +19,6 @@ import java.io.ObjectInputStream;
 import java.io.Serializable;
 
 import jsettlers.algorithms.previewimage.IPreviewImageDataSupplier;
-import jsettlers.common.CommonConstants;
 import jsettlers.common.landscape.ELandscapeType;
 import jsettlers.common.landscape.EResourceType;
 import jsettlers.common.map.IGraphicsBackgroundListener;
@@ -96,7 +95,7 @@ public final class LandscapeGrid implements Serializable, IWalkableGround, IFlat
 	}
 
 	private final void initDebugColors() {
-		if (CommonConstants.ENABLE_DEBUG_COLORS) {
+		if (MatchConstants.ENABLE_DEBUG_COLORS) {
 			this.debugColors = new int[width * height];
 		} else {
 			this.debugColors = null;
@@ -132,13 +131,13 @@ public final class LandscapeGrid implements Serializable, IWalkableGround, IFlat
 
 	@Override
 	public final void setDebugColor(int x, int y, int argb) {
-		if (CommonConstants.ENABLE_DEBUG_COLORS) {
+		if (MatchConstants.ENABLE_DEBUG_COLORS) {
 			debugColors[x + y * width] = argb;
 		}
 	}
 
 	public final int getDebugColor(int x, int y) {
-		if (CommonConstants.ENABLE_DEBUG_COLORS) {
+		if (MatchConstants.ENABLE_DEBUG_COLORS) {
 			return debugColors[x + y * width];
 		} else {
 			return 0;
@@ -146,7 +145,7 @@ public final class LandscapeGrid implements Serializable, IWalkableGround, IFlat
 	}
 
 	public final void resetDebugColors() {
-		if (CommonConstants.ENABLE_DEBUG_COLORS) {
+		if (MatchConstants.ENABLE_DEBUG_COLORS) {
 			for (int i = 0; i < debugColors.length; i++) {
 				debugColors[i] = 0;
 			}

--- a/jsettlers.logic/src/main/java/jsettlers/main/JSettlersGame.java
+++ b/jsettlers.logic/src/main/java/jsettlers/main/JSettlersGame.java
@@ -106,6 +106,7 @@ public class JSettlersGame {
 		MatchConstants.ENABLE_ALL_PLAYER_FOG_OF_WAR = controlAll;
 		MatchConstants.ENABLE_ALL_PLAYER_SELECTION = controlAll;
 		MatchConstants.ENABLE_FOG_OF_WAR_DISABLING = controlAll;
+		MatchConstants.ENABLE_DEBUG_COLORS = controlAll;
 
 		this.gameRunner = new GameRunner();
 	}
@@ -130,7 +131,7 @@ public class JSettlersGame {
 	 * @param playerId
 	 */
 	public JSettlersGame(IGameCreator mapCreator, long randomSeed, byte playerId, PlayerSetting[] playerSettings) {
-		this(mapCreator, randomSeed, new OfflineNetworkConnector(), playerId, playerSettings, true, false, null);
+		this(mapCreator, randomSeed, new OfflineNetworkConnector(), playerId, playerSettings, CommonConstants.CONTROL_ALL, false, null);
 	}
 
 	public static JSettlersGame loadFromReplayFile(ReplayUtils.IReplayStreamProvider loadableReplayFile, INetworkConnector networkConnector,


### PR DESCRIPTION
The control all option was once activated by default for single player games, when there was no AI to play against. With this, the players were able to play themselves. 

As we now have the AI in a very good shape, we can disable this debug option again. In order to use this mode for debugging, use the --control-all command line option.