### PR TITLE
Remove dupplicate :go.graphics.android package.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,6 @@ gradle.ext.projectsWithExtraTest = []
 
 include ':go.graphics'
 include ':go.graphics.swing'
-include ':go.graphics.android'
 include ':jsettlers.buildingcreator'
 include ':jsettlers.common'
 include ':jsettlers.graphics'


### PR DESCRIPTION
This allows to only build the swing components if one does not want to download the SDK.