### PR TITLE
Add cleaning to layout builder generation task.

### DIFF
--- a/jsettlers.graphics/build.gradle
+++ b/jsettlers.graphics/build.gradle
@@ -21,11 +21,17 @@ dependencies {
 }
 
 
+def layoutsFolder = './src/gen/java/jsettlers/graphics/ui/layout'
+
 task generateLayouts(dependsOn: tasks.getByPath(':jsettlers.graphics:layoutbuilder:jar'), type: JavaExec) {
+    doFirst {
+        delete(layoutsFolder)
+        mkdir(layoutsFolder)
+    }
+
     classpath project(":jsettlers.graphics:layoutbuilder").sourceSets.main.runtimeClasspath
     main = "jsettlers.graphics.ui.generate.LayoutConverter"
     args = [file('./src/main/res/layout').absolutePath, file('./src/gen/java').absolutePath]
     inputs.dir file('./src/main/res/layout')
-    outputs.dir file('./src/gen/java/jsettlers/graphics/ui/layout')
+    outputs.dir file(layoutsFolder)
 }
-


### PR DESCRIPTION
This prevents errors when switching from a branch with new layouts to a branch without those layouts.