### PR TITLE
select the right image for wine goods

### DIFF
--- a/jsettlers.common/src/main/java/jsettlers/common/material/EMaterialType.java
+++ b/jsettlers.common/src/main/java/jsettlers/common/material/EMaterialType.java
@@ -51,7 +51,7 @@ public enum EMaterialType {
 	SWORD((short) 59, 14, 111, true, 13, false),
 	TRUNK((short) 41, 3, 171, true, 2, false),
 	WATER((short) 77, 3, 156, true, 12, false),
-	WINE((short) 69, 14, 123, true, 25, false),
+	WINE((short) 69, 14, 129, true, 25, false),
 
 	// Now the non-droppable materials
 


### PR DESCRIPTION
Wine uses currently the image of sulfur, see below:

![goodsonmaster](https://user-images.githubusercontent.com/5322205/38769242-b2943b72-3fff-11e8-8082-cc44088c1b0b.JPG)
![templeonmaster](https://user-images.githubusercontent.com/5322205/38769244-b4cc9b50-3fff-11e8-9800-253f6aa75107.JPG)

I changed the offset in the image file to pick the right image (bottle) for the wine:

![goodsonbranch](https://user-images.githubusercontent.com/5322205/38769248-cdfb211e-3fff-11e8-8826-86cebef84bce.JPG)
![templeonbranch](https://user-images.githubusercontent.com/5322205/38769249-cf98a4f6-3fff-11e8-8ceb-46cc63e6fee3.JPG)
