### PR TITLE
Added Docker build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you experience troubles / find a bug, help us fix it. The JSettlers game crea
 3. In the game's folder, there is a subfolder ```resources/logs/``` containing a folder of log files for every game you played. Please package the folder belonging to your game where you experienced the bug (identifiable by date and map name). This folder contains the following files:
   1. *_out.log: This is the console / debugging output of the game.
   2. *_replay.log: This file contains all game relevant actions you and other players did in the game (e.g. place a building, send soldiers somewhere). With this game, we can recalculate your game and debug it to find the exact source of your trouble.
-4. Specify the game time when you first experienced the bug (the game time can be found in the upper right corner while playing). 
+4. Specify the game time when you first experienced the bug (the game time can be found in the upper right corner while playing).
 5. If you were playing a custom map, please attach the map. Without it, replaying the game won't be possible.
 6. Describe what problem you experienced so that we can easily understand it.
 
@@ -36,7 +36,7 @@ After that, follow the detailed installation instructions for you platform.
 5. Run the "JSettlers.jar" file.
   1. On the first start, the game will ask you for the folder where you've installed / unziped (see step 1) the original Settlers III. Please select the respective folder and continue.
   2. Have fun and enjoy the game!
-6. Please have a look at the [manual](https://github.com/jsettlers/settlers-remake/wiki/JSettlers-Manual). The current state of the game lacks some controls known from the original, but also contains new ways to do things, which you shouldn't miss. 
+6. Please have a look at the [manual](https://github.com/jsettlers/settlers-remake/wiki/JSettlers-Manual). The current state of the game lacks some controls known from the original, but also contains new ways to do things, which you shouldn't miss.
 
 #### Arch Linux
 1. Install [jsettlers-git](https://aur.archlinux.org/packages/jsettlers-git/) from the AUR.
@@ -45,14 +45,14 @@ After that, follow the detailed installation instructions for you platform.
 4. See instructions above
 
 #### Configuration Flags
-As described before, the game's UI is still lacking a lot of features. That's why we have to offer some configurations via an options file. You can find a default `options.prp` file aside the `JSettlers.jar` file after you unpacked the archive. 
+As described before, the game's UI is still lacking a lot of features. That's why we have to offer some configurations via an options file. You can find a default `options.prp` file aside the `JSettlers.jar` file after you unpacked the archive.
 
-When opening the file, you will see several options that can be enabled by uncommenting them (remove the # at the beginning of the respective line). This is also described in the file. 
+When opening the file, you will see several options that can be enabled by uncommenting them (remove the # at the beginning of the respective line). This is also described in the file.
 
 **Possible configurations include:**
 - all-ai: Let all players be played by the AI. You will be able to watch all AI players and to "assist" them during the game.
 - fixed-ai-type=YYYYY: Option to specify an AI type that shall be used for all AI players. The default behavior is to use a the weakest AI type for the first player and increase the difficulty for every player. Possible values: ROMAN_VERY_EASY, ROMAN_EASY, ROMAN_HARD, ROMAN_VERY_HARD
-- disable-ai: If this flag is enabled, no AI players will be present in single player games. 
+- disable-ai: If this flag is enabled, no AI players will be present in single player games.
 - locale: If you want to test a different localization than your systems default, it can be specify with this option. The value should look like: en_en.
 
 **Command line flags**
@@ -66,7 +66,7 @@ All the options above can also be specified as command line options. For this, y
 4. Install JSettlers by running the downloaded file.
 
 ## Build instructions and developer's guide
-The [build instructions](https://github.com/jsettlers/settlers-remake/wiki/Compiling-using-gradle) and the [developer's guide](https://github.com/jsettlers/settlers-remake/wiki/Developer's%20Guide) can be found in our wiki.
+The [build instructions](https://github.com/jsettlers/settlers-remake/wiki/Compiling-using-gradle) and the [developer's guide](https://github.com/jsettlers/settlers-remake/wiki/Developer's%20Guide) can be found in our wiki. Alternatively, you can follow also the [Docker based build instructions](./docs/build-using-docker.md) for building the desktop variant and the dedicated server.
 
 ## Getting in Touch
-Besides the possibility to report bugs on Github you can also join our [JSettlers Discord](https://discord.gg/2hVV4u6). Here you can discuss on development questions and find other players to meet with. 
+Besides the possibility to report bugs on Github you can also join our [JSettlers Discord](https://discord.gg/2hVV4u6). Here you can discuss on development questions and find other players to meet with.

--- a/docs/build-using-docker.md
+++ b/docs/build-using-docker.md
@@ -1,0 +1,38 @@
+# Build Using Docker
+
+<!-- TOC depthFrom:2 -->
+
+- [Linux Build Instructions](#linux-build-instructions)
+- [Windows Build Instructions](#windows-build-instructions)
+
+<!-- /TOC -->
+
+To avoid installing and configuring all the tools such as the Oracle JDK locally on your machine you can use Docker to build the desktop variant and dedicated server of "JSettlers" in an isolated environment.
+
+## Linux Build Instructions
+
+Run the following commands on Linux based systems:
+
+```
+git clone https://github.com/subesokun/settlers-remake.git
+cd settlers-remake
+
+docker run -it --rm -e "GRADLE_OPTS=-Xmx600m -Dorg.gradle.jvmargs=-Xmx1500m" -v "${PWD}":/home/gradle gradle:jdk8 ./gradlew releaseJSettlers releaseDedicatedServer --stacktrace
+```
+
+The generated release files will be copied into the `./release` folder
+
+## Windows Build Instructions
+
+Run the following commands on Windows:
+
+> Note: Be extra careful to not forget the `--config core.autocrlf=input` argument when cloning the repository on Windows as otherwise the Docker build will fail. If you've cloned already the repository without this argument you've to delete and clone it again.
+
+```
+git clone https://github.com/subesokun/settlers-remake.git --config core.autocrlf=input
+cd settlers-remake
+
+docker run -it --rm -e "GRADLE_OPTS=-Xmx600m -Dorg.gradle.jvmargs=-Xmx1500m" -v %cd%:/home/gradle gradle:jdk8 ./gradlew releaseJSettlers releaseDedicatedServer --stacktrace
+```
+
+The generated release files will be copied into the `./release` folder


### PR DESCRIPTION
As I didn't want to install and configure all the tooling such as the Oracle JDK or Gradle on my system I thought it might be a good idea if I share how JSettlers can be build locally from source using Docker as there seems to be no "master" releases on Github (or?). Unfortunately, I can't contribute to the Wiki hence I added a markdown file with the build instructions.